### PR TITLE
feat: update project for Oscar 2026 with edition support

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -14,6 +14,9 @@
   },
   "name": "back",
   "version": "1.0.0",
+  "engines": {
+    "node": "24.x"
+  },
   "main": "index.js",
   "scripts": {
     "start": "npx tsc && node build/app.js",

--- a/back/src/configs/firebase.ts
+++ b/back/src/configs/firebase.ts
@@ -1,13 +1,38 @@
 import admin from 'firebase-admin';
 import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
 
 dotenv.config();
 
-// Initialize Firebase Admin SDK
-const serviceAccount = require(process.env.FIREBASE_SDK_ADMIN_JSON_PATH || '');
+const resolveCredentialPath = () => {
+    const configuredPath = process.env.FIREBASE_SDK_ADMIN_JSON_PATH;
 
-admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount)
-});
+    if (!configuredPath) {
+        return null;
+    }
+
+    const candidatePaths = [
+        configuredPath,
+        configuredPath.replace('\\Documentos\\', '\\Documents\\'),
+        path.resolve(process.cwd(), configuredPath),
+    ];
+
+    return candidatePaths.find((candidatePath) => fs.existsSync(candidatePath)) ?? null;
+};
+
+const credentialPath = resolveCredentialPath();
+
+if (credentialPath) {
+    const serviceAccount = require(credentialPath);
+
+    admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount)
+    });
+} else {
+    console.warn('Firebase Admin credentials not found. Firebase-dependent routes will return 503 until FIREBASE_SDK_ADMIN_JSON_PATH points to a valid service account file.');
+}
+
+export const isFirebaseAdminAvailable = () => admin.apps.length > 0;
 
 export default admin;

--- a/back/src/controllers/betController.ts
+++ b/back/src/controllers/betController.ts
@@ -2,30 +2,48 @@ import { Request, Response } from 'express';
 import { db } from '../db/dbOperations';
 import { ObjectId } from 'mongodb';
 import { Nominee } from '../models/nominee';
-import { Bet } from '../models/bet';
-import { User } from '../models/user';
+import { Bet, BetSelection } from '../models/bet';
 import { Category } from '../models/category';
 import NomineeService from '../services/nomineeService';
+import EditionService from '../services/editionService';
 
 class BetController {
     async createBet(req: Request, res: Response) {
         const user = req.user;
-        const bets = req.body as Bet[];
+        const incomingBets = req.body as BetSelection | Bet[];
         const poolId = req.params.poolId;
-
-        // Check the date to see if the user can update the bets
-        const currentDate = new Date();
-
-        // Oscar date: March 2, 2025, 9 PM (Brasília time)
-        const oscarDate = new Date("2025-03-02T21:00:00-03:00");
-
-        if (currentDate > oscarDate) {
-            res.status(400).send('Bets are closed');
-            return;
-        }
 
         try {
             const pools = db.collection('pools');
+
+            const pool = await pools.findOne(
+                {
+                    _id: ObjectId.createFromHexString(poolId),
+                    'users.user': user._id
+                },
+                {
+                    projection: {
+                        editionKey: 1,
+                    }
+                }
+            );
+
+            if (!pool) {
+                res.status(404).send('Pool not found');
+                return;
+            }
+
+            const currentDate = new Date();
+            const oscarDate = await EditionService.getBetDeadline(pool.editionKey);
+
+            if (currentDate > oscarDate) {
+                res.status(400).send('Bets are closed');
+                return;
+            }
+
+            const bets: BetSelection = Array.isArray(incomingBets)
+                ? { userBets: incomingBets }
+                : incomingBets;
 
             const userBets = await pools.findOne(
                 {
@@ -68,7 +86,6 @@ class BetController {
     
         try {
             const poolsCollection = db.collection('pools');
-            const winnersCollection = db.collection('winners');
     
             // Get user bets
             const pool = await poolsCollection.findOne(
@@ -78,6 +95,7 @@ class BetController {
                 },
                 {
                     projection: {
+                        editionKey: 1,
                         categories: 1,
                         'users.$': 1
                     }
@@ -90,17 +108,18 @@ class BetController {
             }
 
             // Get nominees
-            const nominees = await NomineeService.getNominees();
+            const editionKey = pool.editionKey;
+            const nominees = await NomineeService.getNominees(editionKey);
 
             // Filter by categories in pool
             const poolCategories = pool.categories.map((category: any) => category.category);
             const poolNominees = nominees.filter((category: Category) => poolCategories.includes(category.category));
 
             // Get winners
-            const winners = await winnersCollection.find().toArray();
+            const edition = await EditionService.resolveEdition(editionKey);
 
             // Get user bets
-            const userBets = pool.users[0].bets;
+            const userBets = pool.users[0].bets as BetSelection | undefined;
 
             type BetNominee = Nominee & { isWinner: boolean };
 
@@ -119,7 +138,7 @@ class BetController {
                                 name: nominee,
                                 detail: category.nominees.find((nomineeData: Nominee) => nomineeData.name === nominee)?.detail || '',
                                 movieImage: category.nominees.find((nomineeData: Nominee) => nomineeData.name === nominee)?.movieImage || '',
-                                isWinner: winners.some((winner) => winner.category === bet.category && winner.nominee === nominee)
+                                isWinner: edition.categories.find((entry) => entry.category === bet.category)?.winner === nominee
                             });
                         });
 
@@ -138,7 +157,7 @@ class BetController {
                     category.nominees.forEach((nominee: Nominee) => {
                         betNominees.push({
                             ...nominee,
-                            isWinner: winners.some((winner) => winner.category === category.category && winner.nominee === nominee.name)
+                            isWinner: edition.categories.find((entry) => entry.category === category.category)?.winner === nominee.name
                         });
                     });
 
@@ -150,11 +169,8 @@ class BetController {
                 });
             }
 
-            // Check the date to see if the user can update the bets
             const currentDate = new Date();
-
-            // Oscar date: March 2, 2025, 9 PM (Brasília time)
-            const oscarDate = new Date("2025-03-02T21:00:00-03:00");
+            const oscarDate = await EditionService.getBetDeadline(editionKey);
 
             const canUpdateBets = currentDate < oscarDate;
 

--- a/back/src/controllers/betController.ts
+++ b/back/src/controllers/betController.ts
@@ -111,62 +111,90 @@ class BetController {
             const editionKey = pool.editionKey;
             const nominees = await NomineeService.getNominees(editionKey);
 
-            // Filter by categories in pool
+            // Filter by categories currently configured in the pool
             const poolCategories = pool.categories.map((category: any) => category.category);
             const poolNominees = nominees.filter((category: Category) => poolCategories.includes(category.category));
+            const poolCategoryWeights = new Map<string, number>(
+                pool.categories.map((category: any) => [category.category, category.weight])
+            );
+            const poolCategorySet = new Set(poolCategories);
 
             // Get winners
             const edition = await EditionService.resolveEdition(editionKey);
 
             // Get user bets
             const userBets = pool.users[0].bets as BetSelection | undefined;
+            const storedBets = userBets?.userBets ?? [];
 
             type BetNominee = Nominee & { isWinner: boolean };
 
             const userBetsInfo: { category: string; weight: number; nominees: (Nominee & { isWinner: boolean; })[]; }[] = [];
 
-            // Get user bets with isWinners
-            if (userBets) {
-                userBets.userBets.forEach((bet: Bet) => {
-                    const category = poolNominees.find((category: Category) => category.category === bet.category);
+            // Normalize stored bets: keep only categories and nominees still valid for current pool config.
+            const normalizedStoredBets: Bet[] = storedBets
+                .filter((bet) => poolCategorySet.has(bet.category))
+                .map((bet) => {
+                    const categoryData = poolNominees.find((entry) => entry.category === bet.category);
+                    const allowedNominees = new Set((categoryData?.nominees ?? []).map((nominee) => nominee.name));
 
-                    if (category) {
-                        const betNominees: BetNominee[] = [];
+                    return {
+                        category: bet.category,
+                        nominees: bet.nominees.filter((nominee) => allowedNominees.has(nominee)),
+                    };
+                });
 
-                        bet.nominees.forEach((nominee: string) => {
-                            betNominees.push({
-                                name: nominee,
-                                detail: category.nominees.find((nomineeData: Nominee) => nomineeData.name === nominee)?.detail || '',
-                                movieImage: category.nominees.find((nomineeData: Nominee) => nomineeData.name === nominee)?.movieImage || '',
-                                isWinner: edition.categories.find((entry) => entry.category === bet.category)?.winner === nominee
-                            });
-                        });
+            // Always return categories from the current pool config, even if the user has no stored ranking yet.
+            poolNominees.forEach((category: Category) => {
+                const betNominees: BetNominee[] = [];
+                const storedCategoryBet = normalizedStoredBets.find((bet) => bet.category === category.category);
+                const nomineeByName = new Map(category.nominees.map((nominee) => [nominee.name, nominee]));
+                const orderedNominees: Nominee[] = [];
+                const includedNominees = new Set<string>();
 
-                        userBetsInfo.push({
-                            category: bet.category,
-                            weight: pool.categories.find((categoryData: any) => categoryData.category === bet.category).weight,
-                            nominees: betNominees
-                        });
+                (storedCategoryBet?.nominees ?? []).forEach((nomineeName) => {
+                    const nomineeData = nomineeByName.get(nomineeName);
+
+                    if (nomineeData && !includedNominees.has(nomineeName)) {
+                        orderedNominees.push(nomineeData);
+                        includedNominees.add(nomineeName);
                     }
                 });
-            } else {
-                // If user has no bets, return all categories with nominees and winners
-                poolNominees.forEach((category: Category) => {
-                    const betNominees: BetNominee[] = [];
 
-                    category.nominees.forEach((nominee: Nominee) => {
-                        betNominees.push({
-                            ...nominee,
-                            isWinner: edition.categories.find((entry) => entry.category === category.category)?.winner === nominee.name
-                        });
-                    });
+                category.nominees.forEach((nominee) => {
+                    if (!includedNominees.has(nominee.name)) {
+                        orderedNominees.push(nominee);
+                    }
+                });
 
-                    userBetsInfo.push({
-                        category: category.category,
-                        weight: pool.categories.find((categoryData: any) => categoryData.category === category.category).weight,
-                        nominees: betNominees
+                orderedNominees.forEach((nominee) => {
+                    betNominees.push({
+                        ...nominee,
+                        isWinner: edition.categories.find((entry) => entry.category === category.category)?.winner === nominee.name
                     });
                 });
+
+                userBetsInfo.push({
+                    category: category.category,
+                    weight: poolCategoryWeights.get(category.category) ?? 0,
+                    nominees: betNominees
+                });
+            });
+
+            // Persist cleanup so stale categories are removed from stored bets over time.
+            if (userBets && JSON.stringify(normalizedStoredBets) !== JSON.stringify(storedBets)) {
+                await poolsCollection.updateOne(
+                    {
+                        _id: ObjectId.createFromHexString(poolId),
+                        'users.user': user._id
+                    },
+                    {
+                        $set: {
+                            'users.$.bets': {
+                                userBets: normalizedStoredBets,
+                            }
+                        }
+                    }
+                );
             }
 
             const currentDate = new Date();

--- a/back/src/controllers/editionController.ts
+++ b/back/src/controllers/editionController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import EditionService from '../services/editionService';
+
+class EditionController {
+    async listEditions(_req: Request, res: Response) {
+        try {
+            const editions = await EditionService.listEditions();
+            res.status(200).json(editions);
+        } catch (error) {
+            res.status(500).send('Internal Server Error');
+        }
+    }
+
+    async getActiveEdition(_req: Request, res: Response) {
+        try {
+            const edition = await EditionService.getActiveEdition();
+            res.status(200).json({
+                key: edition.key,
+                label: edition.label,
+                year: edition.year,
+                ceremonyDate: edition.ceremonyDate,
+                betDeadline: edition.betDeadline,
+                isActive: edition.isActive,
+            });
+        } catch (error) {
+            res.status(500).send('Internal Server Error');
+        }
+    }
+
+    async activateEdition(req: Request, res: Response) {
+        try {
+            const edition = await EditionService.activateEdition(req.params.key);
+            res.status(200).json({
+                key: edition.key,
+                label: edition.label,
+                year: edition.year,
+                ceremonyDate: edition.ceremonyDate,
+                betDeadline: edition.betDeadline,
+                isActive: edition.isActive,
+            });
+        } catch (error) {
+            res.status(500).send('Internal Server Error');
+        }
+    }
+}
+
+export default new EditionController();

--- a/back/src/controllers/nomineeController.ts
+++ b/back/src/controllers/nomineeController.ts
@@ -2,13 +2,14 @@ import { Request, Response } from 'express';
 import NomineeService from '../services/nomineeService';
 import { Category } from '../models/category';
 import { Nominee } from '../models/nominee';
-import { db } from '../db/dbOperations';
+import EditionService from '../services/editionService';
 
 class NomineeController {
-    async getCategories(_req: Request, res: Response) {
+    async getCategories(req: Request, res: Response) {
         try {
+            const editionKey = req.query.edition as string | undefined;
             // Get only the categories names from the json file
-            const nominees = await NomineeService.getNominees();
+            const nominees = await NomineeService.getNominees(editionKey);
 
             const categories: string[] = [];
 
@@ -25,8 +26,9 @@ class NomineeController {
     async getNominees(req: Request, res: Response) {
         try {
             const { category } = req.params;
+            const editionKey = req.query.edition as string | undefined;
             
-            const nominees = await NomineeService.getNominees();
+            const nominees = await NomineeService.getNominees(editionKey);
 
             const categoryData = nominees.find((categoryData: Category) => categoryData.category === category);
 
@@ -35,10 +37,10 @@ class NomineeController {
                 return;
             }
 
-            const categoryWinner = await db.collection('winners').findOne({ category });
+            const editionCategory = await EditionService.getCategory(editionKey, category);
 
             const nomineesData = categoryData.nominees.map((nominee: Nominee) => {
-                const isWinner = categoryWinner?.nominee === nominee.name;
+                const isWinner = editionCategory?.winner === nominee.name;
                 return { ...nominee, isWinner };
             });
 
@@ -55,27 +57,11 @@ class NomineeController {
         }
 
         const { category, nominee } = req.body as Winner;
+        const editionKey = (req.body.editionKey || req.query.edition) as string | undefined;
 
         try {
-            const winners = db.collection('winners');
-
-            const existingCategory = await winners.findOne({ category });
-
-            if (existingCategory) {
-                if (existingCategory.nominee === nominee) {
-                    winners.deleteOne({ category });
-                    return res.status(200).send('Winner removed');
-                }
-
-                await winners.updateOne({ category }, { $set: { nominee } });
-                return res.status(200).send('Winner updated');
-            }
-
-            const winner = { category, nominee };
-
-            await winners.insertOne(winner);
-
-            res.status(200).send('Winner registered');
+            const nextWinner = await EditionService.updateWinner(editionKey, category, nominee);
+            res.status(200).send(nextWinner ? 'Winner registered' : 'Winner removed');
         } catch (error) {
             res.status(500).send('Internal Server Error');
         }

--- a/back/src/controllers/poolController.ts
+++ b/back/src/controllers/poolController.ts
@@ -4,10 +4,119 @@ import { Pool } from '../models/pool';
 import { Bet } from '../models/bet';
 import { v4 as uuidv4 } from 'uuid';
 import { ObjectId } from 'mongodb';
+import EditionService, { DEFAULT_FALLBACK_EDITION_KEY } from '../services/editionService';
 
-type PoolCreation = Pick<Pool, 'name' | 'description' | 'public'  | 'categories'>;
+type PoolCreation = Pick<Pool, 'name' | 'description' | 'public'  | 'categories' | 'editionKey'>;
+
+type PoolCursor = {
+    users: number;
+    id: string;
+};
 
 class PoolController{
+    private encodeCursor(cursor: PoolCursor) {
+        return `${cursor.users}:${cursor.id}`;
+    }
+
+    private parseCursor(rawCursor?: string) {
+        if (!rawCursor) {
+            return null;
+        }
+
+        const separatorIndex = rawCursor.indexOf(':');
+
+        if (separatorIndex === -1) {
+            return null;
+        }
+
+        const users = Number(rawCursor.slice(0, separatorIndex));
+        const id = rawCursor.slice(separatorIndex + 1);
+
+        if (Number.isNaN(users) || !ObjectId.isValid(id)) {
+            return null;
+        }
+
+        return {
+            users,
+            id,
+        } satisfies PoolCursor;
+    }
+
+    private getEditionMatch(editionKey?: string) {
+        if (!editionKey) {
+            return null;
+        }
+
+        if (editionKey === DEFAULT_FALLBACK_EDITION_KEY) {
+            return {
+                $or: [
+                    { editionKey: DEFAULT_FALLBACK_EDITION_KEY },
+                    { editionKey: { $exists: false } },
+                ],
+            };
+        }
+
+        return { editionKey };
+    }
+
+    private buildPoolListPipeline(req: Request, baseMatch: Record<string, any>, limit: number, cursor?: string) {
+        const pipeline: Record<string, any>[] = [
+            { $match: baseMatch },
+            {
+                $addFields: {
+                    editionKey: { $ifNull: ['$editionKey', DEFAULT_FALLBACK_EDITION_KEY] },
+                    usersCount: { $size: '$users' },
+                    categoriesCount: { $size: '$categories' },
+                    isAdmin: {
+                        $cond: [
+                            { $in: [req.user._id, '$users.user'] },
+                            { $arrayElemAt: ['$users.admin', { $indexOfArray: ['$users.user', req.user._id] }] },
+                            false,
+                        ],
+                    },
+                    isCreator: { $eq: [req.user._id, '$createdBy'] },
+                    isMember: { $in: [req.user._id, '$users.user'] },
+                },
+            },
+        ];
+
+        const parsedCursor = this.parseCursor(cursor);
+
+        if (parsedCursor) {
+            pipeline.push({
+                $match: {
+                    $or: [
+                        { usersCount: { $lt: parsedCursor.users } },
+                        {
+                            usersCount: parsedCursor.users,
+                            _id: { $gt: ObjectId.createFromHexString(parsedCursor.id) },
+                        },
+                    ],
+                },
+            });
+        }
+
+        pipeline.push(
+            { $sort: { usersCount: -1, _id: 1 } },
+            { $limit: limit },
+            {
+                $project: {
+                    name: 1,
+                    description: 1,
+                    public: 1,
+                    editionKey: 1,
+                    categories: '$categoriesCount',
+                    users: '$usersCount',
+                    isAdmin: 1,
+                    isCreator: 1,
+                    isMember: 1,
+                },
+            },
+        );
+
+        return pipeline;
+    }
+
     async createPool(req: Request, res: Response) {
         try {
             const pool: PoolCreation = req.body;
@@ -17,8 +126,11 @@ class PoolController{
 
             const pools = db.collection('pools');
 
+            const edition = await EditionService.resolveEdition(pool.editionKey);
+
             const newPool: Pool = {
                 ...pool,
+                editionKey: edition.key,
                 inviteToken,
                 users: [{ user: userId, admin: true }],
                 createdBy: userId,
@@ -136,39 +248,21 @@ class PoolController{
 
             const limit = parseInt(req.query.limit as string) || 10;
             const cursor = req.query.cursor as string;
+            const editionKey = req.query.editionKey as string | undefined;
 
-            const query: any = {
+            const baseQuery: any = {
                 $or: [
                     { public: true },
                     { users: { $elemMatch: { user: req.user._id } } }
                 ]
             }
 
-            if (cursor) {
-                query['_id'] = { $gt: ObjectId.createFromHexString(cursor) };
-            }
+            const editionMatch = this.getEditionMatch(editionKey);
+            const query = editionMatch ? { $and: [baseQuery, editionMatch] } : baseQuery;
 
-            const result = await pools
-                .find(query, {
-                    projection: {
-                        name: 1,
-                        description: 1,
-                        public: 1,
-                        categories: { $size: "$categories" },
-                        users: { $size: "$users" },
-                        isAdmin: { $cond: [{ $in: [req.user._id, "$users.user"] }, { $arrayElemAt: ["$users.admin", { $indexOfArray: ["$users.user", req.user._id] }] }, false] },
-                        isCreator: { $eq: [req.user._id, "$createdBy"] },
-                        isMember: { $in: [req.user._id, "$users.user"] }
-                    }
-                })
-                .sort({
-                    users: -1,
-                    _id: 1
-                })
-                .limit(limit)
-                .toArray();
+            const result = await pools.aggregate(this.buildPoolListPipeline(req, query, limit, cursor)).toArray();
             
-            const lastCursor = result.length > 0 ? result[result.length - 1]._id : null;
+            const lastCursor = result.length > 0 ? this.encodeCursor({ users: result[result.length - 1].users, id: result[result.length - 1]._id.toString() }) : null;
 
             res.status(200).send({
                 pools: result,
@@ -187,36 +281,18 @@ class PoolController{
 
             const limit = parseInt(req.query.limit as string) || 10;
             const cursor = req.query.cursor as string;
+            const editionKey = req.query.editionKey as string | undefined;
 
-            const query: any = {
+            const baseQuery: any = {
                 users: { $elemMatch: { user: req.user._id } }
             };
 
-            if (cursor) {
-                query['_id'] = { $gt: ObjectId.createFromHexString(cursor) };
-            }
+            const editionMatch = this.getEditionMatch(editionKey);
+            const query = editionMatch ? { $and: [baseQuery, editionMatch] } : baseQuery;
 
-            const result = await pools
-                .find(query, {
-                    projection: {
-                        name: 1,
-                        description: 1,
-                        public: 1,
-                        categories: { $size: "$categories" },
-                        users: { $size: "$users" },
-                        isAdmin: { $cond: [{ $in: [req.user._id, "$users.user"] }, { $arrayElemAt: ["$users.admin", { $indexOfArray: ["$users.user", req.user._id] }] }, false] },
-                        isCreator: { $eq: [req.user._id, "$createdBy"] },
-                        isMember: { $in: [req.user._id, "$users.user"] }
-                    }
-                })
-                .sort({
-                    users: -1,
-                    _id: 1
-                })
-                .limit(limit)
-                .toArray();
+            const result = await pools.aggregate(this.buildPoolListPipeline(req, query, limit, cursor)).toArray();
 
-            const lastCursor = result.length > 0 ? result[result.length - 1]._id : null;
+            const lastCursor = result.length > 0 ? this.encodeCursor({ users: result[result.length - 1].users, id: result[result.length - 1]._id.toString() }) : null;
 
             res.status(200).send({
                 pools: result,
@@ -236,8 +312,9 @@ class PoolController{
             const limit = parseInt(req.query.limit as string) || 10;
             const cursor = req.query.cursor as string;
             const search = req.query.search as string;
+            const editionKey = req.query.editionKey as string | undefined;
 
-            const query: any = {
+            const baseQuery: any = {
                 $and: [
                     {
                         $or: [
@@ -254,31 +331,12 @@ class PoolController{
                 ]
             };
 
-            if (cursor) {
-                query['_id'] = { $gt: ObjectId.createFromHexString(cursor) };
-            }
+            const editionMatch = this.getEditionMatch(editionKey);
+            const query = editionMatch ? { $and: [baseQuery, editionMatch] } : baseQuery;
 
-            const result = await pools
-                .find(query, {
-                    projection: {
-                        name: 1,
-                        description: 1,
-                        public: 1,
-                        categories: { $size: "$categories" },
-                        users: { $size: "$users" },
-                        isAdmin: { $cond: [{ $in: [req.user._id, "$users.user"] }, { $arrayElemAt: ["$users.admin", { $indexOfArray: ["$users.user", req.user._id] }] }, false] },
-                        isCreator: { $eq: [req.user._id, "$createdBy"] },
-                        isMember: { $in: [req.user._id, "$users.user"] }
-                    }
-                })
-                .sort({
-                    users: -1,
-                    _id: 1
-                })
-                .limit(limit)
-                .toArray();
+            const result = await pools.aggregate(this.buildPoolListPipeline(req, query, limit, cursor)).toArray();
 
-            const lastCursor = result.length > 0 ? result[result.length - 1]._id : null;
+            const lastCursor = result.length > 0 ? this.encodeCursor({ users: result[result.length - 1].users, id: result[result.length - 1]._id.toString() }) : null;
 
             res.status(200).send({
                 pools: result,
@@ -303,6 +361,7 @@ class PoolController{
                     projection: {
                         name: 1,
                         description: 1,
+                        editionKey: { $ifNull: ['$editionKey', DEFAULT_FALLBACK_EDITION_KEY] },
                         public: 1,
                         categories: { $size: "$categories" },
                         users: { $size: "$users" },
@@ -337,6 +396,7 @@ class PoolController{
                     projection: {
                         name: 1,
                         description: 1,
+                        editionKey: { $ifNull: ['$editionKey', DEFAULT_FALLBACK_EDITION_KEY] },
                         public: 1,
                         inviteToken: 1,
                         categories: 1,
@@ -400,8 +460,6 @@ class PoolController{
         try {
             const poolId = req.params.poolId as string;
             const pools = db.collection('pools');
-            const winners = db.collection('winners');
-
             // Get the pool info
             const pool = await pools.findOne(
                 { _id: ObjectId.createFromHexString(poolId) },
@@ -409,6 +467,7 @@ class PoolController{
                     projection: {
                         name: 1,
                         description: 1,
+                        editionKey: 1,
                         public: 1,
                         categories: 1,
                         users: 1,
@@ -431,17 +490,12 @@ class PoolController{
                 return;
             }
 
-            // Get the winners from the categories of the pool
-            const poolCategories = Array.isArray(pool.categories) ? pool.categories.map((category: any) => category.category) : [pool.categories.category];
-
-            const categoryWinners = await winners.find({
-                category: { $in: poolCategories }
-            }).toArray();
-
-            // Map the winners to the categories
             const winnersMap = new Map<string, string>();
-            categoryWinners.forEach(winner => {
-                winnersMap.set(winner.category, winner.nominee);
+            const edition = await EditionService.resolveEdition(pool.editionKey);
+            edition.categories.forEach((category) => {
+                if (category.winner) {
+                    winnersMap.set(category.category, category.winner);
+                }
             });
 
             // Calculate the leaderboard

--- a/back/src/controllers/userController.ts
+++ b/back/src/controllers/userController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { db } from '../db/dbOperations';
 import { User } from '../models/user';
-import admin from '../configs/firebase';
+import admin, { isFirebaseAdminAvailable } from '../configs/firebase';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
@@ -10,8 +10,21 @@ import { ObjectId } from 'mongodb';
 dotenv.config();
 
 class UserController {
+    private ensureFirebaseAdmin(res: Response) {
+        if (!isFirebaseAdminAvailable()) {
+            res.status(503).send('Firebase Admin is not configured');
+            return false;
+        }
+
+        return true;
+    }
+
     async register(req: Request, res: Response) {
         try {
+            if (!this.ensureFirebaseAdmin(res)) {
+                return;
+            }
+
             type UserRegister = Pick<User, 'username' | 'email' | 'password' | 'googleId'>;
 
             const user: UserRegister = req.body;
@@ -123,6 +136,10 @@ class UserController {
 
     async updateUser(req: Request, res: Response) {
         try {
+            if (!this.ensureFirebaseAdmin(res)) {
+                return;
+            }
+
             const userId = req.user._id;
             const { username } = req.body;
     
@@ -172,6 +189,10 @@ class UserController {
         const { email, newPassword } = req.body;
 
         try {
+            if (!this.ensureFirebaseAdmin(res)) {
+                return;
+            }
+
             const user = await db.collection<User>('users').findOne({
                 email
             });

--- a/back/src/data/editionSeeds.ts
+++ b/back/src/data/editionSeeds.ts
@@ -1,0 +1,271 @@
+import { EditionCategory } from '../models/edition';
+import { Nominee } from '../models/nominee';
+
+const OSCAR_2026_PLACEHOLDER = '/nominees/oscar_2026_placeholder.svg';
+
+const nominee = (name: string, detail: string): Nominee => ({
+    name,
+    detail,
+    movieImage: OSCAR_2026_PLACEHOLDER,
+});
+
+export const OSCAR_2026_CATEGORIES: EditionCategory[] = [
+    {
+        category: 'nominees.category.actor',
+        nominees: [
+            nominee('Timothée Chalamet', 'Marty Supreme'),
+            nominee('Leonardo DiCaprio', 'One Battle After Another'),
+            nominee('Ethan Hawke', 'Blue Moon'),
+            nominee('Michael B. Jordan', 'Sinners'),
+            nominee('Wagner Moura', 'The Secret Agent'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.supportingActor',
+        nominees: [
+            nominee('Benicio del Toro', 'One Battle After Another'),
+            nominee('Jacob Elordi', 'Frankenstein'),
+            nominee('Delroy Lindo', 'Sinners'),
+            nominee('Sean Penn', 'One Battle After Another'),
+            nominee('Stellan Skarsgård', 'Sentimental Value'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.actress',
+        nominees: [
+            nominee('Jessie Buckley', 'Hamnet'),
+            nominee('Rose Byrne', "If I Had Legs I'd Kick You"),
+            nominee('Kate Hudson', 'Song Sung Blue'),
+            nominee('Renate Reinsve', 'Sentimental Value'),
+            nominee('Emma Stone', 'Bugonia'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.supportingActress',
+        nominees: [
+            nominee('Elle Fanning', 'Sentimental Value'),
+            nominee('Inga Ibsdotter Lilleaas', 'Sentimental Value'),
+            nominee('Amy Madigan', 'Weapons'),
+            nominee('Wunmi Mosaku', 'Sinners'),
+            nominee('Teyana Taylor', 'One Battle After Another'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.animatedFeature',
+        nominees: [
+            nominee('Arco', 'Ugo Bienvenu, Félix de Givry, Sophie Mas, Natalie Portman'),
+            nominee('Elio', 'Madeline Sharafian, Domee Shi, Adrian Molina, Mary Alice Drumm'),
+            nominee('KPop Demon Hunters', 'Maggie Kang, Chris Appelhans, Michelle L. M. Wong'),
+            nominee('Little Amélie or the Character of Rain', 'Maïlys Vallade, Liane-Cho Han, Nidia Santiago, Henri Magalon'),
+            nominee('Zootopia 2', 'Jared Bush, Byron Howard, Yvett Merino'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.animatedShort',
+        nominees: [
+            nominee('Butterfly', 'Florence Miailhe, Ron Dyens'),
+            nominee('Forevergreen', 'Nathan Engelhardt, Jeremy Spears'),
+            nominee('The Girl Who Cried Pearls', 'Chris Lavis, Maciek Szczerbowski'),
+            nominee('Retirement Plan', 'John Kelly, Andrew Freedman'),
+            nominee('The Three Sisters', 'Konstantin Bronzit'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.cinematography',
+        nominees: [
+            nominee('Frankenstein', 'Dan Laustsen'),
+            nominee('Marty Supreme', 'Darius Khondji'),
+            nominee('One Battle After Another', 'Michael Bauman'),
+            nominee('Sinners', 'Autumn Durald Arkapaw'),
+            nominee('Train Dreams', 'Adolpho Veloso'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.costumeDesign',
+        nominees: [
+            nominee('Avatar: Fire and Ash', 'Deborah L. Scott'),
+            nominee('Frankenstein', 'Kate Hawley'),
+            nominee('Hamnet', 'Malgosia Turzanska'),
+            nominee('Marty Supreme', 'Miyako Bellizzi'),
+            nominee('Sinners', 'Ruth E. Carter'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.directing',
+        nominees: [
+            nominee('Hamnet', 'Chloé Zhao'),
+            nominee('Marty Supreme', 'Josh Safdie'),
+            nominee('One Battle After Another', 'Paul Thomas Anderson'),
+            nominee('Sentimental Value', 'Joachim Trier'),
+            nominee('Sinners', 'Ryan Coogler'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.documentaryFeature',
+        nominees: [
+            nominee('The Alabama Solution', 'Andrew Jarecki, Charlotte Kaufman'),
+            nominee('Come See Me in the Good Light', 'Ryan White, Jessica Hargrave, Tig Notaro, Stef Willen'),
+            nominee('Cutting Through Rocks', 'Sara Khaki, Mohammadreza Eyni'),
+            nominee('Mr Nobody Against Putin', 'David Borenstein, Pavel Talankin, Helle Faber, Alžběta Karásková'),
+            nominee('The Perfect Neighbor', 'Geeta Gandbhir, Alisa Payne, Nikon Kwantu, Sam Bisbee'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.documentaryShort',
+        nominees: [
+            nominee('All the Empty Rooms', 'Joshua Seftel, Conall Jones'),
+            nominee('Armed Only with a Camera: The Life and Death of Brent Renaud', 'Craig Renaud, Juan Arredondo'),
+            nominee('Children No More: "Were and Are Gone"', 'Hilla Medalia, Sheila Nevins'),
+            nominee('The Devil Is Busy', 'Christalyn Hampton, Geeta Gandbhir'),
+            nominee('Perfectly a Strangeness', 'Alison McAlpine'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.filmEditing',
+        nominees: [
+            nominee('F1', 'Stephen Mirrione'),
+            nominee('Marty Supreme', 'Ronald Bronstein, Josh Safdie'),
+            nominee('One Battle After Another', 'Andy Jurgensen'),
+            nominee('Sentimental Value', 'Olivier Bugge Coutté'),
+            nominee('Sinners', 'Michael P. Shawver'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.internationalFeature',
+        nominees: [
+            nominee('It Was Just an Accident', 'France'),
+            nominee('The Secret Agent', 'Brazil'),
+            nominee('Sentimental Value', 'Norway'),
+            nominee('Sirāt', 'Spain'),
+            nominee('The Voice of Hind Rajab', 'Tunisia'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.makeupAndHairstyling',
+        nominees: [
+            nominee('Frankenstein', 'Mike Hill, Jordan Samuel, Cliona Furey'),
+            nominee('Kokuho', 'Kyoko Toyokawa, Naomi Hibino, Tadashi Nishimatsu'),
+            nominee('Sinners', 'Ken Diaz, Mike Fontaine, Shunika Terry'),
+            nominee('The Smashing Machine', 'Kazu Hiro, Glen Griffin, Bjoern Rehbein'),
+            nominee('The Ugly Stepsister', 'Thomas Foldberg, Anne Cathrine Sauerberg'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.musicOriginalScore',
+        nominees: [
+            nominee('Bugonia', 'Jerskin Fendrix'),
+            nominee('Frankenstein', 'Alexandre Desplat'),
+            nominee('Hamnet', 'Max Richter'),
+            nominee('One Battle After Another', 'Jonny Greenwood'),
+            nominee('Sinners', 'Ludwig Göransson'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.musicOriginalSong',
+        nominees: [
+            nominee('Dear Me', 'Diane Warren: Relentless — Diane Warren'),
+            nominee('Golden', 'KPop Demon Hunters — Ejae, Mark Sonnenblick, 24, Ido, Teddy Park'),
+            nominee('I Lied to You', 'Sinners — Raphael Saadiq, Ludwig Göransson'),
+            nominee('Sweet Dreams of Joy', 'Viva Verdi! — Nicholas Pike'),
+            nominee('Train Dreams', 'Train Dreams — Nick Cave, Bryce Dessner'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.bestPicture',
+        nominees: [
+            nominee('Bugonia', 'Ed Guiney, Andrew Lowe, Yorgos Lanthimos, Emma Stone, Lars Knudsen'),
+            nominee('F1', 'Chad Oman, Brad Pitt, Dede Gardner, Jeremy Kleiner, Joseph Kosinski, Jerry Bruckheimer'),
+            nominee('Frankenstein', 'Guillermo del Toro, J. Miles Dale, Scott Stuber'),
+            nominee('Hamnet', 'Liza Marshall, Pippa Harris, Nicolas Gonda, Steven Spielberg, Sam Mendes'),
+            nominee('Marty Supreme', 'Eli Bush, Ronald Bronstein, Josh Safdie, Anthony Katagas, Timothée Chalamet'),
+            nominee('One Battle After Another', 'Adam Somner, Sara Murphy, Paul Thomas Anderson'),
+            nominee('The Secret Agent', 'Emilie Lesclaux'),
+            nominee('Sentimental Value', 'Maria Ekerhovd, Andrea Berentsen Ottmar'),
+            nominee('Sinners', 'Zinzi Coogler, Sev Ohanian, Ryan Coogler'),
+            nominee('Train Dreams', 'Marissa McMahon, Teddy Schwarzman, Will Janowitz, Ashley Schlaifer, Michael Heimler'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.productionDesign',
+        nominees: [
+            nominee('Frankenstein', 'Tamara Deverell, Shane Vieau'),
+            nominee('Hamnet', 'Fiona Crombie, Alice Felton'),
+            nominee('Marty Supreme', 'Jack Fisk, Adam Willis'),
+            nominee('One Battle After Another', 'Florencia Martin, Anthony Carlino'),
+            nominee('Sinners', 'Hannah Beachler, Monique Champagne'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.liveActionShort',
+        nominees: [
+            nominee("Butcher's Stain", 'Meyer Levinson-Blount, Oron Caspi'),
+            nominee('A Friend of Dorothy', 'Lee Knight, James Dean'),
+            nominee("Jane Austen's Period Drama", 'Julia Aks, Steve Pinder'),
+            nominee('The Singers', 'Sam A. Davis, Jack Piatt'),
+            nominee('Two People Exchanging Saliva', 'Alexandre Singh, Natalie Musteata'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.sound',
+        nominees: [
+            nominee('F1', 'Gareth John, Al Nelson, Gwendolyn Yates Whittle, Gary A. Rizzo, Juan Peralta'),
+            nominee('Frankenstein', 'Greg Chapman, Nathan Robitaille, Nelson Ferreira, Christian Cooke, Brad Zoern'),
+            nominee('One Battle After Another', 'José Antonio García, Christopher Scarabosio, Tony Villaflor'),
+            nominee('Sinners', 'Chris Welcker, Benjamin A. Burtt, Felipe Pacheco, Brandon Proctor, Steve Boeddeker'),
+            nominee('Sirāt', 'Amanda Villavieja, Laia Casanovas, Yasmina Praderas'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.visualEffects',
+        nominees: [
+            nominee('Avatar: Fire and Ash', 'Joe Letteri, Richard Baneham, Eric Saindon, Daniel Barrett'),
+            nominee('F1', 'Ryan Tudhope, Nicolas Chevallier, Robert Harrington, Keith Dawson'),
+            nominee('Jurassic World Rebirth', 'David Vickery, Stephen Aplin, Charmaine Chan, Neil Corbould'),
+            nominee('The Lost Bus', 'Charlie Noble, David Zaretti, Russell Bowen, Brandon K. McLaughlin'),
+            nominee('Sinners', 'Michael Ralla, Espen Nordahl, Guido Wolter, Donnie Dean'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.writingAdaptedScreenplay',
+        nominees: [
+            nominee('Bugonia', 'Screenplay by Will Tracy'),
+            nominee('Frankenstein', 'Written for the screen by Guillermo del Toro'),
+            nominee('Hamnet', "Screenplay by Chloé Zhao & Maggie O'Farrell"),
+            nominee('One Battle After Another', 'Written by Paul Thomas Anderson'),
+            nominee('Train Dreams', 'Screenplay by Clint Bentley & Greg Kwedar'),
+        ],
+        winner: null,
+    },
+    {
+        category: 'nominees.category.writingOriginalScreenplay',
+        nominees: [
+            nominee('Blue Moon', 'Written by Robert Kaplow'),
+            nominee('It Was Just an Accident', 'Jafar Panahi with Nader Saïvar, Shadmehr Rastin, Mehdi Mahmoudian'),
+            nominee('Marty Supreme', 'Written by Ronald Bronstein & Josh Safdie'),
+            nominee('Sentimental Value', 'Written by Eskil Vogt and Joachim Trier'),
+            nominee('Sinners', 'Written by Ryan Coogler'),
+        ],
+        winner: null,
+    },
+];

--- a/back/src/models/bet.ts
+++ b/back/src/models/bet.ts
@@ -2,3 +2,7 @@ export interface Bet {
     category: string;
     nominees: string[];
 }
+
+export interface BetSelection {
+    userBets: Bet[];
+}

--- a/back/src/models/edition.ts
+++ b/back/src/models/edition.ts
@@ -1,0 +1,23 @@
+import { ObjectId } from 'mongodb';
+import { Nominee } from './nominee';
+
+export interface EditionCategory {
+    category: string;
+    nominees: Nominee[];
+    winner?: string | null;
+}
+
+export interface Edition {
+    _id?: ObjectId;
+    key: string;
+    label: string;
+    year: number;
+    ceremonyDate: Date;
+    betDeadline: Date;
+    isActive: boolean;
+    categories: EditionCategory[];
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export type EditionSummary = Pick<Edition, 'key' | 'label' | 'year' | 'ceremonyDate' | 'betDeadline' | 'isActive'>;

--- a/back/src/models/pool.ts
+++ b/back/src/models/pool.ts
@@ -1,10 +1,10 @@
 import { ObjectId } from "mongodb";
-import { Bet } from "./bet";
+import { BetSelection } from "./bet";
 
 type UserPool = {
     user: ObjectId;
     admin: boolean;
-    bets?: Bet[];
+    bets?: BetSelection;
 };
 
 type CategoryPool = {
@@ -16,6 +16,7 @@ export interface Pool {
     _id?: ObjectId;
     name: string;
     description?: string;
+    editionKey?: string;
     public: boolean;
     inviteToken?: string;
     categories: CategoryPool[];

--- a/back/src/routes/editionRouter.ts
+++ b/back/src/routes/editionRouter.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import EditionController from '../controllers/editionController';
+import { adminMiddleware } from '../middlewares/adminMiddleware';
+
+export const editionRouter = express.Router();
+
+editionRouter.get('/', EditionController.listEditions);
+editionRouter.get('/active', EditionController.getActiveEdition);
+editionRouter.put('/:key/activate', adminMiddleware, EditionController.activateEdition);

--- a/back/src/routes/index.ts
+++ b/back/src/routes/index.ts
@@ -5,10 +5,12 @@ import { userRouter } from './userRouter';
 import { betRouter } from './betRouter';
 import { nomineeRouter } from './nomineeRouter';
 import { poolRouter } from './poolRouter';
+import { editionRouter } from './editionRouter';
 
 export const routes = express.Router();
 
 routes.use(userRouter);
 routes.use('/bet', betRouter);
+routes.use('/editions', editionRouter);
 routes.use(nomineeRouter);
 routes.use('/pools', poolRouter);

--- a/back/src/routes/poolRouter.ts
+++ b/back/src/routes/poolRouter.ts
@@ -14,13 +14,13 @@ poolRouter.put('/updatePool/:poolId', authMiddleware, PoolController.updatePool)
 poolRouter.delete('/deletePool/:poolId', authMiddleware, PoolController.deletePool);
 
 // Get pools info ordered by number of users in the pool
-poolRouter.get('/getPoolsByUserNumber', authMiddleware, PoolController.getPoolsByUserNumber);
+poolRouter.get('/getPoolsByUserNumber', authMiddleware, PoolController.getPoolsByUserNumber.bind(PoolController));
 
 // Get pools by user
-poolRouter.get('/getPoolsByUser', authMiddleware, PoolController.getPoolsByUser);
+poolRouter.get('/getPoolsByUser', authMiddleware, PoolController.getPoolsByUser.bind(PoolController));
 
 // Get pools by search
-poolRouter.get('/getPoolsBySearch', authMiddleware, PoolController.getPoolsBySearch);
+poolRouter.get('/getPoolsBySearch', authMiddleware, PoolController.getPoolsBySearch.bind(PoolController));
 
 // Get pool by token
 poolRouter.get('/getPoolByToken/:token', authMiddleware, PoolController.getPoolByToken);

--- a/back/src/services/editionService.ts
+++ b/back/src/services/editionService.ts
@@ -1,0 +1,253 @@
+import fs from 'fs';
+import path from 'path';
+import { db } from '../db/dbOperations';
+import { OSCAR_2026_CATEGORIES } from '../data/editionSeeds';
+import { Category } from '../models/category';
+import { Edition, EditionCategory, EditionSummary } from '../models/edition';
+
+const DEFAULT_EDITION_KEY = '2025';
+const DEFAULT_ACTIVE_EDITION_KEY = '2026';
+const DEFAULT_OSCAR_2025_DATE = new Date('2025-03-02T21:00:00-03:00');
+const DEFAULT_OSCAR_2026_DATE = new Date('2026-03-15T20:00:00-03:00');
+
+type EditionSeed = Pick<Edition, 'key' | 'label' | 'year' | 'ceremonyDate' | 'betDeadline' | 'isActive' | 'categories'>;
+
+class EditionService {
+    private async dedupeEditions() {
+        const editionsCollection = db.collection<Edition>('editions');
+        const duplicateKeys = await editionsCollection.aggregate<{ _id: string; ids: Edition['_id'][]; count: number }>([
+            {
+                $group: {
+                    _id: '$key',
+                    ids: { $push: '$_id' },
+                    count: { $sum: 1 },
+                },
+            },
+            {
+                $match: {
+                    count: { $gt: 1 },
+                },
+            },
+        ]).toArray();
+
+        for (const duplicateKey of duplicateKeys) {
+            const editions = await editionsCollection.find({ key: duplicateKey._id }).sort({ isActive: -1, updatedAt: -1, createdAt: -1, _id: 1 }).toArray();
+
+            const [editionToKeep, ...duplicatesToDelete] = editions;
+
+            if (!editionToKeep || duplicatesToDelete.length === 0) {
+                continue;
+            }
+
+            await editionsCollection.deleteMany({
+                _id: {
+                    $in: duplicatesToDelete
+                        .map((edition) => edition._id)
+                        .filter((id): id is NonNullable<Edition['_id']> => Boolean(id)),
+                },
+            });
+        }
+    }
+
+    private async ensureIndexes() {
+        await db.collection<Edition>('editions').createIndex({ key: 1 }, { unique: true });
+    }
+
+    private async buildOscar2025Seed(): Promise<EditionSeed> {
+        const nomineesPath = path.join(process.cwd(), 'src', 'data', 'nominees.json');
+        const nomineesData = fs.readFileSync(nomineesPath, 'utf-8');
+        const nominees: Category[] = JSON.parse(nomineesData);
+        const winners = await db.collection<{ category: string; nominee: string }>('winners').find().toArray();
+        const winnersMap = new Map(winners.map((winner) => [winner.category, winner.nominee]));
+
+        const categories: EditionCategory[] = nominees.map((category) => ({
+            ...category,
+            winner: winnersMap.get(category.category) ?? null,
+        }));
+
+        return {
+            key: DEFAULT_EDITION_KEY,
+            label: 'Oscar 2025',
+            year: 2025,
+            ceremonyDate: DEFAULT_OSCAR_2025_DATE,
+            betDeadline: DEFAULT_OSCAR_2025_DATE,
+            isActive: false,
+            categories,
+        };
+    }
+
+    private buildOscar2026Seed(): EditionSeed {
+        return {
+            key: DEFAULT_ACTIVE_EDITION_KEY,
+            label: 'Oscar 2026',
+            year: 2026,
+            ceremonyDate: DEFAULT_OSCAR_2026_DATE,
+            betDeadline: DEFAULT_OSCAR_2026_DATE,
+            isActive: true,
+            categories: OSCAR_2026_CATEGORIES,
+        };
+    }
+
+    private async ensureEdition(seed: EditionSeed) {
+        const now = new Date();
+
+        await db.collection<Edition>('editions').updateOne(
+            { key: seed.key },
+            {
+                $setOnInsert: {
+                    ...seed,
+                    createdAt: now,
+                    updatedAt: now,
+                },
+            },
+            { upsert: true }
+        );
+    }
+
+    private async migrateLegacyPools() {
+        await db.collection('pools').updateMany(
+            {
+                $or: [
+                    { editionKey: { $exists: false } },
+                    { editionKey: null },
+                    { editionKey: '' },
+                ],
+            },
+            {
+                $set: {
+                    editionKey: DEFAULT_EDITION_KEY,
+                },
+            }
+        );
+    }
+
+    private async ensureSeeded() {
+        await this.dedupeEditions();
+        await this.ensureEdition(await this.buildOscar2025Seed());
+        await this.ensureEdition(this.buildOscar2026Seed());
+
+        await db.collection<Edition>('editions').updateMany(
+            { key: { $ne: DEFAULT_ACTIVE_EDITION_KEY }, isActive: true },
+            { $set: { isActive: false, updatedAt: new Date() } }
+        );
+
+        await db.collection<Edition>('editions').updateOne(
+            { key: DEFAULT_ACTIVE_EDITION_KEY },
+            { $set: { isActive: true, updatedAt: new Date() } }
+        );
+
+        await this.migrateLegacyPools();
+        await this.dedupeEditions();
+        await this.ensureIndexes();
+    }
+
+    async listEditions(): Promise<EditionSummary[]> {
+        await this.ensureSeeded();
+
+        return db.collection<Edition>('editions')
+            .find({}, {
+                projection: {
+                    key: 1,
+                    label: 1,
+                    year: 1,
+                    ceremonyDate: 1,
+                    betDeadline: 1,
+                    isActive: 1,
+                },
+            })
+            .sort({ year: -1 })
+            .toArray() as Promise<EditionSummary[]>;
+    }
+
+    async getActiveEdition(): Promise<Edition> {
+        await this.ensureSeeded();
+
+        const activeEdition = await db.collection<Edition>('editions').findOne({ isActive: true });
+
+        if (activeEdition) {
+            return activeEdition;
+        }
+
+        const fallbackEdition = await db.collection<Edition>('editions').findOne({}, { sort: { year: -1 } });
+
+        if (!fallbackEdition) {
+            throw new Error('No editions available');
+        }
+
+        return fallbackEdition;
+    }
+
+    async resolveEdition(editionKey?: string | null): Promise<Edition> {
+        await this.ensureSeeded();
+
+        if (editionKey) {
+            const edition = await db.collection<Edition>('editions').findOne({ key: editionKey });
+
+            if (!edition) {
+                throw new Error(`Edition not found: ${editionKey}`);
+            }
+
+            return edition;
+        }
+
+        return this.getActiveEdition();
+    }
+
+    async getCategories(editionKey?: string | null) {
+        const edition = await this.resolveEdition(editionKey);
+        return edition.categories.map((category) => category.category);
+    }
+
+    async getCategory(editionKey: string | null | undefined, categoryKey: string) {
+        const edition = await this.resolveEdition(editionKey);
+        return edition.categories.find((category) => category.category === categoryKey) ?? null;
+    }
+
+    async updateWinner(editionKey: string | null | undefined, categoryKey: string, nominee: string) {
+        const edition = await this.resolveEdition(editionKey);
+        const category = edition.categories.find((entry) => entry.category === categoryKey);
+
+        if (!category) {
+            throw new Error('Category not found');
+        }
+
+        const nextWinner = category.winner === nominee ? null : nominee;
+
+        await db.collection<Edition>('editions').updateOne(
+            { key: edition.key, 'categories.category': categoryKey },
+            {
+                $set: {
+                    'categories.$.winner': nextWinner,
+                    updatedAt: new Date(),
+                },
+            }
+        );
+
+        return nextWinner;
+    }
+
+    async activateEdition(editionKey: string) {
+        const edition = await this.resolveEdition(editionKey);
+        const now = new Date();
+
+        await db.collection<Edition>('editions').updateMany(
+            { isActive: true },
+            { $set: { isActive: false, updatedAt: now } }
+        );
+
+        await db.collection<Edition>('editions').updateOne(
+            { key: edition.key },
+            { $set: { isActive: true, updatedAt: now } }
+        );
+
+        return this.resolveEdition(edition.key);
+    }
+
+    async getBetDeadline(editionKey?: string | null) {
+        const edition = await this.resolveEdition(editionKey);
+        return edition.betDeadline;
+    }
+}
+
+export const DEFAULT_FALLBACK_EDITION_KEY = DEFAULT_EDITION_KEY;
+export default new EditionService();

--- a/back/src/services/nomineeService.ts
+++ b/back/src/services/nomineeService.ts
@@ -1,14 +1,14 @@
-import path from 'path';
-import fs from 'fs';
 import { Category } from '../models/category';
+import EditionService from './editionService';
 
 class NomineeService {
-    async getNominees() {
-        const nomineesPath = path.join('src', 'data', 'nominees.json');
-        const nomineesData = fs.readFileSync(nomineesPath);
-        const nominees: Category[] = JSON.parse(nomineesData.toString());
+    async getNominees(editionKey?: string | null): Promise<Category[]> {
+        const edition = await EditionService.resolveEdition(editionKey);
 
-        return nominees;
+        return edition.categories.map(({ category, nominees }) => ({
+            category,
+            nominees,
+        }));
     }
 }
 

--- a/front/package.json
+++ b/front/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/front/public/nominees/oscar_2026_placeholder.svg
+++ b/front/public/nominees/oscar_2026_placeholder.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 600" role="img" aria-labelledby="title desc">
+  <title id="title">Oscar 2026 placeholder poster</title>
+  <desc id="desc">A decorative placeholder image for Oscar 2026 nominees.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#6b4f1d" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="600" fill="url(#bg)" rx="24" />
+  <circle cx="200" cy="170" r="68" fill="#f5d26a" opacity="0.18" />
+  <path d="M200 110c-20 0-36 16-36 36 0 13 7 24 17 30l-23 120h84l-23-120c10-6 17-17 17-30 0-20-16-36-36-36zm-18 222h36l10 42h-56l10-42z" fill="#f5d26a" />
+  <text x="200" y="430" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="42" font-weight="700" fill="#f9fafb">Oscar 2026</text>
+  <text x="200" y="472" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#e5e7eb">Nominee poster coming soon</text>
+</svg>

--- a/front/src/components/common/Countdown.tsx
+++ b/front/src/components/common/Countdown.tsx
@@ -1,11 +1,15 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useEdition } from "../../hooks/useEdition";
 
 const Countdown = () => {
     const { t } = useTranslation();
+    const { selectedEdition } = useEdition();
 
-    // Oscar date: March 2, 2025, 9 PM (Brasília time)
-    const oscarDate = new Date("2025-03-02T21:00:00-03:00");
+    const oscarDate = useMemo(
+        () => new Date(selectedEdition?.ceremonyDate ?? "2026-03-15T20:00:00-03:00"),
+        [selectedEdition?.ceremonyDate]
+    );
 
     // State to store the remaining time
     const [timeLeft, setTimeLeft] = useState({
@@ -34,12 +38,14 @@ const Countdown = () => {
         }
         };
 
+        calculateTimeLeft();
+
         // Update the countdown every second
         const timer = setInterval(calculateTimeLeft, 1000);
 
         // Clear the interval when the component unmounts
         return () => clearInterval(timer);
-    }, []);
+    }, [oscarDate]);
 
     return (
         <div className="mx-auto my-4 w-fit flex flex-col md:flex-row">

--- a/front/src/components/common/PoolPreview.tsx
+++ b/front/src/components/common/PoolPreview.tsx
@@ -7,6 +7,7 @@ type Pool = {
     _id: string;
     name: string;
     description: string;
+    editionKey?: string;
     public: boolean;
     categories: number;
     users: number;
@@ -32,8 +33,9 @@ const PoolPreview = ({ pool }: { pool: Pool }) => {
         <div className="card hover:cursor-pointer border border-base-100 hover:border-primary text-base-200" onClick={() => navigate(`/pool/${pool._id}`)}>
             <div className="card-body">
                 <h2 className="card-title">{pool.name}</h2>
-                <p>{pool.description.length > 200 ? `${pool.description.substring(0, 200)}...` : pool.description}</p>
+                <p>{(pool.description || '').length > 200 ? `${pool.description?.substring(0, 200)}...` : pool.description}</p>
                 <div className="card-footer flex items-center gap-2">
+                    {pool.editionKey && <span className="badge badge-outline">{pool.editionKey}</span>}
                     <span className="flex items-center gap-1 text-sm">{pool.users} <FaUsers /></span>
                     <span className="flex items-center gap-1 text-sm">{pool.categories} <FaClipboardList /></span>
                     {badge()}

--- a/front/src/components/layout/Footer.tsx
+++ b/front/src/components/layout/Footer.tsx
@@ -2,6 +2,8 @@ import { useTranslation } from "react-i18next";
 
 const Footer = () => {
   const { t } = useTranslation();
+  const currentYear = new Date().getFullYear();
+  const copyrightYears = currentYear > 2025 ? `2025-${currentYear}` : '2025';
 
   return (
     <footer className="footer bg-primary text-black p-10 w-full bottom-0 mt-auto">
@@ -27,7 +29,7 @@ const Footer = () => {
         <p>
           AcademyBolao
           <br />
-          © 2025 Leandro Rocha.
+          © {copyrightYears} Leandro Rocha.
         </p>
       </aside>
       <nav>

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -1,14 +1,31 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useEdition } from "../../hooks/useEdition";
 
 const Header = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const { editions, selectedEditionKey, setSelectedEditionKey, loading } = useEdition();
+    const user = JSON.parse(localStorage.getItem('user') || '{}');
+    const isAdmin = Boolean(user.admin);
 
     const [isAuthenticated, setIsAuthenticated] = useState(localStorage.getItem('user') !== null);
 
     useEffect(() => {
         setIsAuthenticated(localStorage.getItem('user') !== null);
+    }, [location.pathname]);
+
+    useEffect(() => {
+        const syncAuthentication = () => {
+            setIsAuthenticated(localStorage.getItem('user') !== null);
+        };
+
+        window.addEventListener('storage', syncAuthentication);
+
+        return () => {
+            window.removeEventListener('storage', syncAuthentication);
+        };
     }, []);
 
     // Handle Theme Change
@@ -38,9 +55,32 @@ const Header = () => {
         navigate("/login");
     };
 
+    const editionSelector = (
+        <div className="flex w-full max-w-xs items-center justify-between gap-3 rounded-box border border-base-300 bg-base-100/90 px-3 py-2 text-base-content shadow-sm">
+            <div className="min-w-0">
+                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-base-content/60">{t('edition.selectorLabel')}</p>
+                <p className="truncate text-sm font-medium">{editions.find((edition) => edition.key === selectedEditionKey)?.label ?? t('edition.unavailable')}</p>
+            </div>
+            <select
+                className="select select-bordered select-sm w-32 bg-base-100 text-base-content"
+                value={selectedEditionKey ?? ''}
+                disabled={loading || editions.length === 0}
+                onChange={(event) => setSelectedEditionKey(event.target.value)}
+            >
+                {editions.length === 0 && (
+                    <option value="">{loading ? t('edition.loading') : t('edition.unavailable')}</option>
+                )}
+                {editions.map((edition) => (
+                    <option key={edition.key} value={edition.key}>{edition.label}</option>
+                ))}
+            </select>
+        </div>
+    );
+
     return (
-        <div className="navbar bg-primary text-black">
-            <div className="navbar-start">
+        <div className="navbar min-h-fit flex-col gap-3 bg-primary px-3 py-3 text-black lg:flex-row lg:flex-wrap lg:justify-between">
+            <div className="flex w-full flex-wrap items-center gap-3 lg:w-auto lg:flex-1">
+                <div className="navbar-start w-auto">
                 {isAuthenticated && (
                     <div className="dropdown">
                         <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
@@ -68,21 +108,26 @@ const Header = () => {
                         </ul>
                     </div>
                 )}
+                </div>
+
+                <div className="flex flex-1 items-center justify-center gap-2 lg:justify-start">
+                    <img src="/assets/favicon/icon.svg" alt="icon" className="hidden h-6 w-6 md:block" style={{ filter: "brightness(0)" }} />
+                    <Link className="btn btn-ghost px-2 text-xl font-light" to="/">AcademyBolao</Link>
+                    <img src="/assets/favicon/icon.svg" alt="icon" className="hidden h-6 w-6 md:block" style={{ filter: "brightness(0)" }} />
+                </div>
             </div>
 
-            <div className="navbar-center">
-                <img src="/assets/favicon/icon.svg" alt="icon" className="h-6 w-6 mr-2 hidden md:block" style={{ filter: "brightness(0)" }} />
-                <a className="btn btn-ghost text-xl font-light" href="/">AcademyBolao</a>
-                <img src="/assets/favicon/icon.svg" alt="icon" className="h-6 w-6 ml-2 hidden md:block" style={{ filter: "brightness(0)" }} />
+            <div className="order-3 flex w-full justify-center lg:order-2 lg:w-auto lg:flex-1">
+                {editionSelector}
             </div>
 
-            <div className="navbar-end">
+            <div className="navbar-end order-2 ml-auto w-auto lg:order-3">
                 {isAuthenticated ? (
                     <div className="dropdown dropdown-end">
                         <div tabIndex={0} role="button" className="btn btn-ghost btn-circle avatar">
                             <div className="w-10 rounded-full">
                             <img
-                                alt={t('images/alt/Flow')}
+                                alt={t('images.alt.Flow')}
                                 src="/assets/images/Flow.PNG" />
                             </div>
                         </div>
@@ -90,6 +135,7 @@ const Header = () => {
                             tabIndex={0}
                             className="menu menu-sm dropdown-content bg-primary rounded-box z-[1] mt-3 w-52 p-2 shadow">
                             <li><a onClick={() => navigate("/user")}>{t('pages.profile')}</a></li>
+                            {isAdmin && <li><a onClick={() => navigate('/admin')}>{t('pages.admin')}</a></li>}
                             
                             {/* Settings option */}
                             <li>

--- a/front/src/contexts/EditionContext.tsx
+++ b/front/src/contexts/EditionContext.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useMemo, useState } from 'react';
+import api from '../libs/api';
+import { EditionSummary } from '../models/edition';
+import { EditionContext } from './editionContext';
+
+const STORAGE_KEY = 'selectedEditionKey';
+
+export const EditionProvider = ({ children }: { children: React.ReactNode }) => {
+    const [editions, setEditions] = useState<EditionSummary[]>([]);
+    const [activeEdition, setActiveEdition] = useState<EditionSummary | null>(null);
+    const [selectedEditionKey, setSelectedEditionKeyState] = useState<string | null>(localStorage.getItem(STORAGE_KEY));
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchEditions = async () => {
+            setLoading(true);
+
+            try {
+                const [editionsResponse, activeResponse] = await Promise.all([
+                    api.get<EditionSummary[]>('/editions'),
+                    api.get<EditionSummary>('/editions/active'),
+                ]);
+
+                const availableEditions = editionsResponse.data.filter((edition, index, editionsList) => (
+                    editionsList.findIndex((candidate) => candidate.key === edition.key) === index
+                ));
+                const currentActiveEdition = activeResponse.data;
+                const persistedEdition = localStorage.getItem(STORAGE_KEY);
+                const nextSelectedEdition = availableEditions.find((edition) => edition.key === persistedEdition)
+                    ?? availableEditions.find((edition) => edition.key === currentActiveEdition.key)
+                    ?? availableEditions[0]
+                    ?? null;
+
+                setEditions(availableEditions);
+                setActiveEdition(currentActiveEdition);
+                setSelectedEditionKeyState(nextSelectedEdition?.key ?? null);
+
+                if (nextSelectedEdition?.key) {
+                    localStorage.setItem(STORAGE_KEY, nextSelectedEdition.key);
+                }
+            } catch (error) {
+                console.error('Error loading editions:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchEditions();
+    }, []);
+
+    const setSelectedEditionKey = (editionKey: string) => {
+        setSelectedEditionKeyState(editionKey);
+        localStorage.setItem(STORAGE_KEY, editionKey);
+    };
+
+    const selectedEdition = useMemo(() => {
+        return editions.find((edition) => edition.key === selectedEditionKey) ?? activeEdition;
+    }, [editions, selectedEditionKey, activeEdition]);
+
+    return (
+        <EditionContext.Provider value={{
+            editions,
+            activeEdition,
+            selectedEdition,
+            selectedEditionKey: selectedEdition?.key ?? null,
+            setSelectedEditionKey,
+            loading,
+        }}>
+            {children}
+        </EditionContext.Provider>
+    );
+};

--- a/front/src/contexts/editionContext.ts
+++ b/front/src/contexts/editionContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+import { EditionSummary } from '../models/edition';
+
+export type EditionContextValue = {
+    editions: EditionSummary[];
+    activeEdition: EditionSummary | null;
+    selectedEdition: EditionSummary | null;
+    selectedEditionKey: string | null;
+    setSelectedEditionKey: (editionKey: string) => void;
+    loading: boolean;
+};
+
+export const EditionContext = createContext<EditionContextValue | undefined>(undefined);

--- a/front/src/hooks/useEdition.ts
+++ b/front/src/hooks/useEdition.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { EditionContext } from '../contexts/editionContext';
+
+export const useEdition = () => {
+    const context = useContext(EditionContext);
+
+    if (!context) {
+        throw new Error('useEdition must be used within an EditionProvider');
+    }
+
+    return context;
+};

--- a/front/src/libs/api.ts
+++ b/front/src/libs/api.ts
@@ -20,7 +20,13 @@ api.interceptors.response.use(
     return response;
   },
   (error) => {
-    if (error.response?.status === 401) {
+    const requestUrl = String(error?.config?.url || '');
+    const isAuthRequest = /\/login\/?$/.test(requestUrl);
+    const isPublicAuthPath = ['/login', '/register', '/reset-password', '/action-handler'].some((path) =>
+      window.location.pathname.startsWith(path)
+    );
+
+    if (error.response?.status === 401 && !isAuthRequest && !isPublicAuthPath) {
       localStorage.removeItem('user');
       window.location.href = '/login?redirect=' + window.location.pathname;
     }

--- a/front/src/libs/api.ts
+++ b/front/src/libs/api.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { useNavigate } from "react-router-dom";
 
 axios.defaults.withCredentials = true;
 
@@ -23,8 +22,7 @@ api.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       localStorage.removeItem('user');
-      const navigate = useNavigate();
-      navigate('/login?redirect=' + window.location.pathname);
+      window.location.href = '/login?redirect=' + window.location.pathname;
     }
     return Promise.reject(error);
   }

--- a/front/src/locales/en.json
+++ b/front/src/locales/en.json
@@ -207,6 +207,19 @@
             "subtitle": "Check out the nominees for {{edition}}",
             "viewAll": "View all"
         },
+        "scoring": {
+            "title": "How Scoring Works",
+            "steps": [
+                "Rank nominees in order from most likely to least likely to win.",
+                "Points are based on where your correct pick was ranked.",
+                "1st place correct pick: 100% of the category weight.",
+                "2nd place correct pick: 60% of the category weight.",
+                "3rd place correct pick: 40% of the category weight.",
+                "4th place correct pick: 20% of the category weight."
+            ],
+            "example": "Example: in Best Picture with weight 200, if your 1st ranked movie wins you score 200 points; if your 2nd ranked movie wins you score 120 points.",
+            "button": "Detailed Guide"
+        },
         "hero": {
             "title": "Welcome to the AcademyBolao!",
             "description": {

--- a/front/src/locales/en.json
+++ b/front/src/locales/en.json
@@ -98,7 +98,13 @@
     "pages": {
         "home": "Home",
         "profile": "Profile",
+        "admin": "Admin",
         "nominees": "Nominees"
+    },
+    "edition": {
+        "selectorLabel": "Edition",
+        "loading": "Loading editions",
+        "unavailable": "No editions"
     },
     "logout": "Logout",
     "nominees": {
@@ -198,7 +204,7 @@
     "homePage": {
         "nominees": {
             "title": "Nominees",
-            "subtitle": "Check out the 2025 Oscar nominees",
+            "subtitle": "Check out the nominees for {{edition}}",
             "viewAll": "View all"
         },
         "hero": {
@@ -214,6 +220,22 @@
             },
             "login": "Register or login now!"
         }
+    },
+    "adminPage": {
+        "title": "Admin panel",
+        "subtitle": "Manage active editions and review Oscar data.",
+        "active": "Active edition",
+        "activate": "Activate",
+        "activating": "Activating...",
+        "alreadyActive": "Active now",
+        "selected": "Selected",
+        "goToNominees": "Manage winners",
+        "winnerHint": "Winner toggles are still managed in the nominees page.",
+        "activationSuccess": "Edition activated successfully.",
+        "activationError": "Failed to activate edition.",
+        "loadError": "Failed to load editions.",
+        "ceremonyDate": "Ceremony",
+        "betDeadline": "Bet deadline"
     },
     "createPoolPage": {
         "title": "Create pool",

--- a/front/src/locales/pt.json
+++ b/front/src/locales/pt.json
@@ -99,7 +99,13 @@
     "pages": {
         "home": "Início",
         "profile": "Perfil",
+        "admin": "Administração",
         "nominees": "Indicados"
+    },
+    "edition": {
+        "selectorLabel": "Edição",
+        "loading": "Carregando edições",
+        "unavailable": "Sem edições"
     },
     "logout": "Sair",
     "nominees": {
@@ -199,7 +205,7 @@
     "homePage": {
         "nominees": {
             "title": "Indicados",
-            "subtitle": "Confira os indicados ao Oscar 2025",
+            "subtitle": "Confira os indicados do {{edition}}",
             "viewAll": "Ver todos"
         },
         "hero": {
@@ -215,6 +221,22 @@
             },
             "login": "Registre-se ou entre agora!"
         }
+    },
+    "adminPage": {
+        "title": "Painel administrativo",
+        "subtitle": "Gerencie a edição ativa e revise os dados do Oscar.",
+        "active": "Edição ativa",
+        "activate": "Ativar",
+        "activating": "Ativando...",
+        "alreadyActive": "Ativa",
+        "selected": "Selecionada",
+        "goToNominees": "Gerenciar vencedores",
+        "winnerHint": "Os vencedores continuam sendo marcados na página de indicados.",
+        "activationSuccess": "Edição ativada com sucesso.",
+        "activationError": "Falha ao ativar a edição.",
+        "loadError": "Falha ao carregar as edições.",
+        "ceremonyDate": "Cerimônia",
+        "betDeadline": "Prazo das apostas"
     },
     "createPoolPage": {
         "title": "Criar bolão",

--- a/front/src/locales/pt.json
+++ b/front/src/locales/pt.json
@@ -208,6 +208,19 @@
             "subtitle": "Confira os indicados do {{edition}}",
             "viewAll": "Ver todos"
         },
+        "scoring": {
+            "title": "Como a Pontuacao Funciona",
+            "steps": [
+                "Ordene os indicados do mais provavel ao menos provavel de vencer.",
+                "A pontuacao depende da posicao em que seu palpite correto ficou.",
+                "Acerto na 1a posicao: 100% do peso da categoria.",
+                "Acerto na 2a posicao: 60% do peso da categoria.",
+                "Acerto na 3a posicao: 40% do peso da categoria.",
+                "Acerto na 4a posicao: 20% do peso da categoria."
+            ],
+            "example": "Exemplo: em Melhor Filme com peso 200, se o filme que voce colocou em 1o vencer voce ganha 200 pontos; se vencer o seu 2o, voce ganha 120 pontos.",
+            "button": "Guia Detalhado"
+        },
         "hero": {
             "title": "Bem-vindo(a) ao AcademyBolao",
             "description": {

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -3,9 +3,12 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './styles/globalStyles.css'
 import './i18n.ts'
+import { EditionProvider } from './contexts/EditionContext.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <EditionProvider>
+      <App />
+    </EditionProvider>
   </React.StrictMode>,
 )

--- a/front/src/models/edition.ts
+++ b/front/src/models/edition.ts
@@ -1,0 +1,8 @@
+export interface EditionSummary {
+    key: string;
+    label: string;
+    year: number;
+    ceremonyDate: string;
+    betDeadline: string;
+    isActive: boolean;
+}

--- a/front/src/models/pool.ts
+++ b/front/src/models/pool.ts
@@ -3,7 +3,7 @@ import { Bet } from "./bet";
 type UserPool = {
     user: string;
     admin: boolean;
-    bets?: Bet[];
+    bets?: { userBets: Bet[] };
 };
 
 type CategoryPool = {
@@ -15,10 +15,11 @@ export interface Pool {
     _id?: string;
     name: string;
     description?: string;
+    editionKey?: string;
     public: boolean;
     inviteToken?: string;
     categories: CategoryPool[];
     users: UserPool[];
     createdBy: string;
     createdAt: string;
-};
+}

--- a/front/src/pages/Admin/AdminPage.tsx
+++ b/front/src/pages/Admin/AdminPage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import api from '../../libs/api';
+import Title from '../../components/ui/Title';
+import SuccessMessage from '../../components/common/SuccessMessage';
+import ErrorMessage from '../../components/common/ErrorMessage';
+import { EditionSummary } from '../../models/edition';
+import { useEdition } from '../../hooks/useEdition';
+
+const AdminPage = () => {
+    const { t, i18n } = useTranslation();
+    const navigate = useNavigate();
+    const { activeEdition, selectedEditionKey, setSelectedEditionKey } = useEdition();
+    const [editions, setEditions] = useState<EditionSummary[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [activatingKey, setActivatingKey] = useState<string | null>(null);
+    const [successMessage, setSuccessMessage] = useState('');
+    const [errorMessage, setErrorMessage] = useState('');
+
+    const locale = useMemo(() => (i18n.language === 'pt' ? 'pt-BR' : 'en-US'), [i18n.language]);
+
+    const formatDate = (date: string) => new Intl.DateTimeFormat(locale, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(date));
+
+    const loadEditions = async () => {
+        setLoading(true);
+        setErrorMessage('');
+
+        try {
+            const response = await api.get<EditionSummary[]>('/editions');
+            const uniqueEditions = response.data.filter((edition, index, editionList) => (
+                editionList.findIndex((candidate) => candidate.key === edition.key) === index
+            ));
+            setEditions(uniqueEditions);
+        } catch (error) {
+            setErrorMessage(t('adminPage.loadError'));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadEditions();
+    }, []);
+
+    const activateEdition = async (editionKey: string) => {
+        setActivatingKey(editionKey);
+        setSuccessMessage('');
+        setErrorMessage('');
+
+        try {
+            await api.put(`/editions/${editionKey}/activate`);
+            setSelectedEditionKey(editionKey);
+            setSuccessMessage(t('adminPage.activationSuccess'));
+            await loadEditions();
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            setErrorMessage(typeof axiosError.response?.data === 'string' ? axiosError.response.data : t('adminPage.activationError'));
+        } finally {
+            setActivatingKey(null);
+        }
+    };
+
+    return (
+        <div className="mx-2 my-4 md:mx-auto md:w-[900px] text-base-200">
+            <Title>{t('adminPage.title')}</Title>
+            <p className="mb-2 text-center text-base-content/80">{t('adminPage.subtitle')}</p>
+            {activeEdition && <div className="badge badge-primary mb-4">{t('adminPage.active')}: {activeEdition.label}</div>}
+
+            <div className="mb-4 flex justify-center">
+                <button className="btn btn-primary" onClick={() => navigate('/nominees')}>
+                    {t('adminPage.goToNominees')}
+                </button>
+            </div>
+
+            <div className="alert mb-4">
+                <span>{t('adminPage.winnerHint')}</span>
+            </div>
+
+            {loading ? (
+                <div className="grid gap-4 md:grid-cols-2">
+                    {[1, 2].map((item) => <div key={item} className="skeleton h-48 w-full rounded-box"></div>)}
+                </div>
+            ) : (
+                <div className="grid gap-4 md:grid-cols-2">
+                    {editions.map((edition) => {
+                        const isActive = edition.isActive;
+                        const isSelected = selectedEditionKey === edition.key;
+
+                        return (
+                            <div key={edition.key} className="card border border-primary bg-base-100 shadow-xl">
+                                <div className="card-body">
+                                    <div className="flex items-center justify-between gap-2">
+                                        <h2 className="card-title">{edition.label}</h2>
+                                        <div className="flex gap-2">
+                                            {isActive && <span className="badge badge-primary">{t('adminPage.alreadyActive')}</span>}
+                                            {isSelected && <span className="badge badge-outline">{t('adminPage.selected')}</span>}
+                                        </div>
+                                    </div>
+                                    <p><strong>{t('adminPage.ceremonyDate')}:</strong> {formatDate(edition.ceremonyDate)}</p>
+                                    <p><strong>{t('adminPage.betDeadline')}:</strong> {formatDate(edition.betDeadline)}</p>
+                                    <div className="card-actions justify-end">
+                                        <button
+                                            className="btn btn-primary"
+                                            disabled={isActive || activatingKey === edition.key}
+                                            onClick={() => activateEdition(edition.key)}
+                                        >
+                                            {activatingKey === edition.key ? t('adminPage.activating') : t('adminPage.activate')}
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            <SuccessMessage message={successMessage} />
+            <ErrorMessage error={errorMessage} />
+        </div>
+    );
+};
+
+export default AdminPage;

--- a/front/src/pages/CreatePool/CreatePool.tsx
+++ b/front/src/pages/CreatePool/CreatePool.tsx
@@ -2,11 +2,12 @@ import { useTranslation } from "react-i18next";
 import { Pool } from "../../models/pool";
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useForm, Controller } from 'react-hook-form';
+import { useForm, Controller, Resolver } from 'react-hook-form';
 import { useState, useEffect } from "react";
 import api from "../../libs/api";
 import { AxiosError } from 'axios';
 import { useNavigate } from "react-router-dom";
+import { useEdition } from "../../hooks/useEdition";
 import Title from "../../components/ui/Title";
 import Button from "../../components/common/Button";
 import CategorySelector from "../../components/common/CategorySelector";
@@ -14,6 +15,7 @@ import WeightAssigner from "../../components/common/WeightAssigner";
 import ErrorMessage from "../../components/common/ErrorMessage";
 
 type PoolForm = Pick<Pool, 'name' | 'description' | 'public'> & {
+    editionKey?: string;
     categories: CategoryPool[];
 };
 
@@ -29,6 +31,7 @@ const CreatePool = () => {
     const [allCategories, setAllCategories] = useState<string[]>([]);
     const [loadingSubmit, setLoadingSubmit] = useState(false);
     const [submitError, setSubmitError] = useState<string>('');
+    const { selectedEdition, selectedEditionKey } = useEdition();
 
     const navigate = useNavigate();
 
@@ -64,7 +67,7 @@ const CreatePool = () => {
         watch,
         formState: { errors }
     } = useForm<PoolForm>({
-        resolver: yupResolver(schema) as any,
+        resolver: yupResolver(schema) as Resolver<PoolForm>,
         defaultValues: {
             name: '',
             description: '',
@@ -76,7 +79,11 @@ const CreatePool = () => {
     // Get all categories
     useEffect(() => {
         try {
-            api.get('/categories')
+            api.get('/categories', {
+                params: {
+                    edition: selectedEditionKey,
+                },
+            })
                 .then(response => {
                     setAllCategories(response.data);
                 })
@@ -87,7 +94,7 @@ const CreatePool = () => {
         } catch (error) {
             console.error('Error getting categories:', error);
         }
-    }, []);
+    }, [selectedEditionKey]);
 
     // Watch selected categories
     const categories = watch('categories');
@@ -113,8 +120,13 @@ const CreatePool = () => {
         try {
             setLoadingSubmit(true);
 
+            const payload: PoolForm = {
+                ...data,
+                editionKey: selectedEditionKey ?? undefined,
+            };
+
             // Create the pool
-            const response = await api.post('/pools/createPool', data);
+            const response = await api.post('/pools/createPool', payload);
 
             // Redirect to the pool page
             navigate(`/pool/${response.data}`);
@@ -131,6 +143,7 @@ const CreatePool = () => {
         document.title = t('createPoolPage.title'),
         <div className="mx-2 md:max-w-[700px] md:mx-auto my-4 text-base-200">
             <Title>{t('createPoolPage.title')}</Title>
+            {selectedEdition && <div className="badge badge-primary mb-4">{selectedEdition.label}</div>}
 
             {/* Breadcrumbs */}
             <div className="breadcrumbs text-md text-base-200 mb-6">

--- a/front/src/pages/FindPools/FindPools.tsx
+++ b/front/src/pages/FindPools/FindPools.tsx
@@ -5,11 +5,13 @@ import Title from "../../components/ui/Title";
 import PoolPreview from "../../components/common/PoolPreview";
 import ErrorMessage from "../../components/common/ErrorMessage";
 import { FaPaste, FaSearch } from "react-icons/fa";
+import { useEdition } from "../../hooks/useEdition";
 
 type Pool = {
     _id: string;
     name: string;
     description: string;
+    editionKey?: string;
     public: boolean;
     categories: number;
     users: number;
@@ -31,12 +33,26 @@ const FindPools = () => {
     const [showInviteModal, setShowInviteModal] = useState<boolean>(false);
     const [loadingJoinPool, setLoadingJoinPool] = useState<boolean>(false);
     const [joinPoolError, setJoinPoolError] = useState<string | null>(null);
+    const loadingRef = useRef(false);
     const observer = useRef<IntersectionObserver>();
+    const requestedCursorsRef = useRef<Set<string>>(new Set());
+    const requestVersionRef = useRef(0);
+    const { selectedEdition, selectedEditionKey } = useEdition();
+
+    const mergePools = (currentPools: Pool[], incomingPools: Pool[]) => {
+        const existingIds = new Set(currentPools.map((pool) => pool._id));
+        return [...currentPools, ...incomingPools.filter((pool) => !existingIds.has(pool._id))];
+    };
 
     // Function to fetch pools
     const fetchPools = useCallback(
-        async (search = "", cursor = "") => {
-            if (loading) return;
+        async (search = "", cursor = "", reset = false, requestVersion = requestVersionRef.current) => {
+            const requestKey = `${selectedEditionKey ?? 'active'}:${search}:${cursor}`;
+
+            if (loadingRef.current || requestedCursorsRef.current.has(requestKey)) return;
+
+            requestedCursorsRef.current.add(requestKey);
+            loadingRef.current = true;
 
             setLoading(true);
 
@@ -44,15 +60,19 @@ const FindPools = () => {
                 const params = new URLSearchParams();
                 if (search) params.append("search", search);
                 if (cursor) params.append("cursor", cursor);
+                if (selectedEditionKey) params.append("editionKey", selectedEditionKey);
 
                 const response = search ? await api.get(`/pools/getPoolsBySearch?${params.toString()}`) : await api.get(`/pools/getPoolsByUserNumber?${params.toString()}`);
                 const data = response.data;
 
-                // If it's a new search (empty cursor), replace the pool list
-                if (!cursor) {
+                if (requestVersion !== requestVersionRef.current) {
+                    return;
+                }
+
+                if (reset || !cursor) {
                     setPools(data.pools);
                 } else {
-                    setPools((prevPools) => [...prevPools, ...data.pools]);
+                    setPools((prevPools) => mergePools(prevPools, data.pools));
                 }
 
                 setNextCursor(data.nextCursor);
@@ -60,33 +80,27 @@ const FindPools = () => {
             } catch (error) {
                 console.error("Error fetching pools: ", error);
             } finally {
+                loadingRef.current = false;
                 setLoading(false);
             }
         },
-        [loading]
+        [selectedEditionKey]
     );
 
     // Effect to fetch pools when searchQuery changes
     useEffect(() => {
         const delayDebounceFn = setTimeout(() => {
-            // Reset pagination states
+            requestVersionRef.current += 1;
+            requestedCursorsRef.current.clear();
             setPools([]);
             setNextCursor(null);
             setHasMore(true);
 
-            // Perform the search
-            fetchPools(searchQuery);
+            fetchPools(searchQuery, "", true, requestVersionRef.current);
         }, 500);
 
         return () => clearTimeout(delayDebounceFn);
-    }, [searchQuery]);
-
-    // Effect to load more pools when the cursor changes (infinite scroll)
-    useEffect(() => {
-        if (nextCursor) {
-            fetchPools(searchQuery, nextCursor);
-        }
-    }, []);
+    }, [searchQuery, fetchPools, selectedEditionKey]);
 
     // IntersectionObserver setup for infinite scroll
     const lastPoolElementRef = useCallback(
@@ -103,7 +117,7 @@ const FindPools = () => {
 
             if (node) observer.current.observe(node);
         },
-        [loading, hasMore, nextCursor]
+        [loading, hasMore, nextCursor, fetchPools, searchQuery]
     );
 
     // Handle invite token search
@@ -135,7 +149,7 @@ const FindPools = () => {
             const response = await api.post(`/pools/joinPool`, joinPool);
 
             if (response.status === 200) {
-                poolInvite!.isMember = true;
+                setPoolInvite((currentPoolInvite) => currentPoolInvite ? { ...currentPoolInvite, isMember: true } : currentPoolInvite);
             }
         } catch (error) {
             setJoinPoolError(t('pool.errors.joinPoolFailed'));
@@ -157,6 +171,7 @@ const FindPools = () => {
                     <div className="hero-overlay bg-opacity-20"></div>
                     <div className="hero-content flex-col">
                         <Title>{t("findPools.title")}</Title>
+                        {selectedEdition && <div className="badge badge-primary mb-2">{selectedEdition.label}</div>}
                         <div className="flex flex-col md:flex-row md:w-[750px] gap-2">
                             <label className="input flex items-center gap-2 md:w-2/3 text-base-200">
                                 <input
@@ -225,6 +240,11 @@ const FindPools = () => {
                             }
                         })}
                     </div>
+                    {!loading && pools.length === 0 && (
+                        <div className="alert mt-4">
+                            <span>{t("findPools.title")}: 0</span>
+                        </div>
+                    )}
                     {loading && <p className="text-center text-base-200"><span className="loading loading-dots loading-lg"></span></p>}
                 </div>
 

--- a/front/src/pages/Home/HomeComponent.tsx
+++ b/front/src/pages/Home/HomeComponent.tsx
@@ -74,6 +74,25 @@ const HomePage = () => {
 					/>
 				</figure>
 			</div>
+
+			<div className="card bg-base-100 shadow-xl mx-2 md:w-[700px] md:mx-auto border border-primary my-5 text-base-200">
+				<div className="card-body">
+					<h2 className="card-title text-xl">{t('homePage.scoring.title')}</h2>
+
+					<div className="space-y-2 text-left">
+						{(t('homePage.scoring.steps', { returnObjects: true }) as string[]).map((step, index) => (
+							<p key={step}>
+								<span className="font-semibold mr-2">{index + 1}.</span>
+								{step}
+							</p>
+						))}
+					</div>
+
+					<div className="mt-2 rounded-box border border-base-300 bg-base-200/40 p-3">
+						<p className="text-sm">{t('homePage.scoring.example')}</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	)
 };

--- a/front/src/pages/Home/HomeComponent.tsx
+++ b/front/src/pages/Home/HomeComponent.tsx
@@ -2,11 +2,13 @@ import { useTranslation } from 'react-i18next';
 import Countdown from '../../components/common/Countdown';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { useEdition } from '../../hooks/useEdition';
 
 const HomePage = () => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const [isAuthenticated, setIsAuthenticated] = useState(false);
+	const { selectedEdition } = useEdition();
 
 	useEffect(() => {
 		const token = localStorage.getItem('user');
@@ -53,8 +55,8 @@ const HomePage = () => {
 
 			<div className="card card-side bg-base-100 shadow-xl mx-2 md:w-[700px] md:mx-auto border border-primary my-5 text-base-200">
 				<div className="card-body">
-					<h2 className="card-title">{t('homePage.nominees.title')}</h2>
-					<p>{t('homePage.nominees.subtitle')}</p>
+					<h2 className="card-title flex items-center gap-2">{t('homePage.nominees.title')} {selectedEdition && <span className="badge badge-primary">{selectedEdition.label}</span>}</h2>
+					<p>{t('homePage.nominees.subtitle', { edition: selectedEdition?.label ?? 'the Oscars' })}</p>
 					<div className="card-actions">
 						<button
 							className="btn btn-primary"

--- a/front/src/pages/Login/LoginComponent.tsx
+++ b/front/src/pages/Login/LoginComponent.tsx
@@ -6,7 +6,6 @@ import InputField from '../../components/common/InputField';
 import Button from '../../components/common/Button';
 import Account from '../../components/common/Account';
 import FormCard from '../../components/common/FormCard';
-import ErrorMessage from '../../components/common/ErrorMessage';
 import WarningMessage from '../../components/common/WarningMessage';
 import api from '../../libs/api';
 import { AxiosError } from 'axios';
@@ -32,6 +31,7 @@ const LoginPage: React.FC = () => {
     resolver: yupResolver(schema)
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit = async (data: any) => {
     try {
       setLoading(true);
@@ -92,12 +92,17 @@ const LoginPage: React.FC = () => {
           <Button type="submit" loading={loading}>{t('login')}</Button>
         </div>
 
+        {msg && (
+          <div className='w-full text-center text-error text-sm mt-2'>
+            {msg}
+          </div>
+        )}
+
         <Account message={t('dontHaveAnAccount')} linkText={t('createAccount')} link='/register'/>
 
         {errors.emailOrUsername && <WarningMessage error={errors.emailOrUsername.message as string} />}
         {!errors.emailOrUsername && errors.password && <WarningMessage error={errors.password.message as string} />}
 
-        <ErrorMessage error={msg} />
       </FormCard>
     </div>
   );

--- a/front/src/pages/MyPools/MyPools.tsx
+++ b/front/src/pages/MyPools/MyPools.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from "react-i18next";
 import api from "../../libs/api";
 import Title from "../../components/ui/Title";
 import PoolPreview from "../../components/common/PoolPreview";
+import { useEdition } from "../../hooks/useEdition";
 
 type Pool = {
     _id: string;
     name: string;
     description: string;
+    editionKey?: string;
     public: boolean;
     categories: number;
     users: number;
@@ -22,27 +24,40 @@ const MyPools = () => {
     const [nextCursor, setNextCursor] = useState<string | null>(null);
     const [hasMore, setHasMore] = useState<boolean>(true);
     const [loading, setLoading] = useState<boolean>(false);
+    const loadingRef = useRef(false);
     const observer = useRef<IntersectionObserver>();
+    const requestedCursorsRef = useRef<Set<string>>(new Set());
+    const { selectedEdition, selectedEditionKey } = useEdition();
+
+    const mergePools = (currentPools: Pool[], incomingPools: Pool[]) => {
+        const existingIds = new Set(currentPools.map((pool) => pool._id));
+        return [...currentPools, ...incomingPools.filter((pool) => !existingIds.has(pool._id))];
+    };
 
     // Function to fetch user's pools
     const fetchPools = useCallback(
-        async (cursor = "") => {
-            if (loading) return;
+        async (cursor = "", reset = false) => {
+            const requestKey = `${selectedEditionKey ?? 'active'}:${cursor}`;
+
+            if (loadingRef.current || requestedCursorsRef.current.has(requestKey)) return;
+
+            requestedCursorsRef.current.add(requestKey);
+            loadingRef.current = true;
 
             setLoading(true);
 
             try {
                 const params = new URLSearchParams();
                 if (cursor) params.append("cursor", cursor);
+                if (selectedEditionKey) params.append("editionKey", selectedEditionKey);
 
                 const response = await api.get(`/pools/getPoolsByUser?${params.toString()}`);
                 const data = response.data;
 
-                // If it's a new fetch (empty cursor), replace the pool list
-                if (!cursor) {
+                if (reset || !cursor) {
                     setPools(data.pools);
                 } else {
-                    setPools((prevPools) => [...prevPools, ...data.pools]);
+                    setPools((prevPools) => mergePools(prevPools, data.pools));
                 }
 
                 setNextCursor(data.nextCursor);
@@ -50,23 +65,21 @@ const MyPools = () => {
             } catch (error) {
                 console.error("Error fetching pools: ", error);
             } finally {
+                loadingRef.current = false;
                 setLoading(false);
             }
         },
-        [loading]
+        [selectedEditionKey]
     );
 
     // Effect to fetch pools when the component is mounted
     useEffect(() => {
-        fetchPools();
-    }, []);
-
-    // Effect to load more pools when the cursor changes (infinite scroll)
-    useEffect(() => {
-        if (nextCursor) {
-            fetchPools(nextCursor);
-        }
-    }, [nextCursor]);
+        requestedCursorsRef.current.clear();
+        setPools([]);
+        setNextCursor(null);
+        setHasMore(true);
+        fetchPools('', true);
+    }, [fetchPools, selectedEditionKey]);
 
     // IntersectionObserver setup for infinite scroll
     const lastPoolElementRef = useCallback(
@@ -83,7 +96,7 @@ const MyPools = () => {
 
             if (node) observer.current.observe(node);
         },
-        [loading, hasMore, nextCursor]
+        [loading, hasMore, nextCursor, fetchPools]
     );
 
     return (
@@ -92,6 +105,7 @@ const MyPools = () => {
             <>
                 <div className="py-5 mx-2 md:w-[700px] md:mx-auto">
                     <Title>{t("myPools.title")}</Title>
+                    {selectedEdition && <div className="badge badge-primary mb-4">{selectedEdition.label}</div>}
 
                     <div className="flex flex-col">
                         {pools.map((pool, index) => {

--- a/front/src/pages/Nominees/Nominees.tsx
+++ b/front/src/pages/Nominees/Nominees.tsx
@@ -5,15 +5,22 @@ import { AxiosError } from 'axios';
 import NomineeCard from "../../components/common/NomineeCard";
 import NomineeCardSkeleton from "../../components/common/NomineeCardSkeleton";
 import Title from "../../components/ui/Title";
+import { useEdition } from "../../hooks/useEdition";
+import { Nominee as NomineeModel } from "../../models/nominee";
+
+type NomineeViewModel = NomineeModel & {
+    isWinner?: boolean;
+};
 
 const Nominees = () => {
-    const [categories, setCategories] = useState([]);
+    const [categories, setCategories] = useState<string[]>([]);
     const [loadingCategories, setLoadingCategories] = useState(true);
     const [currentCategory, setCurrentCategory] = useState('nominees.category.bestPicture');
-    const [nominees, setNominees] = useState([]);
+    const [nominees, setNominees] = useState<NomineeViewModel[]>([]);
     const [loadingNominees, setLoadingNominees] = useState(true);
     const [isAdmin, setIsAdmin] = useState(false);
     const { t } = useTranslation();
+    const { selectedEdition, selectedEditionKey } = useEdition();
 
     useEffect(() => {
         const user = JSON.parse(localStorage.getItem('user') || '{}');
@@ -24,53 +31,58 @@ const Nominees = () => {
     useEffect(() => {
         setLoadingCategories(true);
 
-        try {
-            api.get('/categories')
-                .then(response => {
-                    setCategories(response.data);
-                })
-                .catch((error) => {
-                    const axiosError = error as AxiosError;
-                    console.error('Error getting categories:', axiosError.response?.data);
-                });
-        } catch (error) {
-            console.error('Error getting categories:', error);
-        }
-
-        setLoadingCategories(false);
-    }, []);
+        api.get('/categories', {
+            params: {
+                edition: selectedEditionKey,
+            },
+        })
+            .then(response => {
+                setCategories(response.data);
+                if (response.data.length > 0 && !response.data.includes(currentCategory)) {
+                    setCurrentCategory(response.data[0]);
+                }
+            })
+            .catch((error) => {
+                const axiosError = error as AxiosError;
+                console.error('Error getting categories:', axiosError.response?.data);
+            })
+            .finally(() => {
+                setLoadingCategories(false);
+            });
+    }, [currentCategory, selectedEditionKey]);
 
     // Get nominees for the current category
 
     const fetchNominees = useCallback(() => {
         setLoadingNominees(true);
 
-        try {
-            api.get(`/nominees/${currentCategory}`)
-                .then(response => {
-                    setNominees(response.data);
-                })
-                .catch((error) => {
-                    const axiosError = error as AxiosError;
-                    console.error('Error getting nominees:', axiosError.response?.data);
-                });
-        } catch (error) {
-            console.error('Error getting nominees:', error);
-        }
-
-        setLoadingNominees(false);
-    }, [currentCategory]);
+        api.get(`/nominees/${currentCategory}`, {
+            params: {
+                edition: selectedEditionKey,
+            },
+        })
+            .then(response => {
+                setNominees(response.data);
+            })
+            .catch((error) => {
+                const axiosError = error as AxiosError;
+                console.error('Error getting nominees:', axiosError.response?.data);
+            })
+            .finally(() => {
+                setLoadingNominees(false);
+            });
+    }, [currentCategory, selectedEditionKey]);
 
     useEffect(() => {
         fetchNominees();
-    }, [currentCategory]);
+    }, [fetchNominees]);
 
     // Handle register winner
-    const handleRegisterWinner = (nominee: any) => {
+    const handleRegisterWinner = (nominee: NomineeViewModel) => {
         if (!isAdmin) return;
 
         try {
-            api.put('/winner', { category: currentCategory, nominee: nominee.name })
+            api.put('/winner', { category: currentCategory, nominee: nominee.name, editionKey: selectedEditionKey })
                 .then(response => {
                     console.log('Winner registered:', response.data);
                     fetchNominees();
@@ -87,13 +99,14 @@ const Nominees = () => {
     return (document.title = t('pages.nominees'), 
         <div className="mx-2 md:w-[700px] md:mx-auto my-4">
             <Title>{t('pages.nominees')}</Title>
+            {selectedEdition && <div className="badge badge-primary mb-2">{selectedEdition.label}</div>}
             <div className="w-full">
                 {loadingCategories ? (
                     <div className="skeleton h-12 rounded-md w-full my-2"></div>
                 ) : (
                     <select className="select select-bordered border-primary w-full my-2" onChange={(e) => setCurrentCategory(e.target.value)} value={currentCategory}>
-                        {categories.map((category: any) => (
-                            <option key={category} value={category} onClick={() => setCurrentCategory(category)} selected={currentCategory === category}>
+                        {categories.map((category) => (
+                            <option key={category} value={category}>
                                 {t(category)}
                             </option>
                         ))}
@@ -104,9 +117,9 @@ const Nominees = () => {
                 {!loadingNominees ? (
                     <div className="nominees">
                         <ul>
-                            {nominees.map((nominee: any) => (
+                            {nominees.map((nominee) => (
                                 <li key={nominee.name} onDoubleClick={() => handleRegisterWinner(nominee)}>
-                                    <NomineeCard {...nominee} winner={nominee.winner} />
+                                    <NomineeCard {...nominee} isWinner={nominee.isWinner} />
                                 </li>
                             ))}
                         </ul>

--- a/front/src/pages/PoolInfo/Components/EditPool.tsx
+++ b/front/src/pages/PoolInfo/Components/EditPool.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, Resolver } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import api from "../../../libs/api";
@@ -10,6 +10,8 @@ import CategorySelector from "../../../components/common/CategorySelector";
 import WeightAssigner from "../../../components/common/WeightAssigner";
 import ErrorMessage from "../../../components/common/ErrorMessage";
 import AreYouSure from "../../../components/common/AreYouSure";
+import { useEdition } from "../../../hooks/useEdition";
+import { Pool } from "../../../models/pool";
 
 type PoolForm = {
     name: string;
@@ -18,7 +20,9 @@ type PoolForm = {
     categories: { category: string; weight: number }[];
 };
 
-const EditPool = ({ pool, fetchPool }: { pool: any, fetchPool: Function }) => {
+type EditablePool = Pick<Pool, '_id' | 'name' | 'description' | 'public' | 'categories' | 'editionKey'>;
+
+const EditPool = ({ pool, fetchPool }: { pool: EditablePool, fetchPool: () => void | Promise<void> }) => {
     const { t } = useTranslation();
     const [loading, setLoading] = useState(true);
     const [loadingCategories, setLoadingCategories] = useState(true);
@@ -26,6 +30,7 @@ const EditPool = ({ pool, fetchPool }: { pool: any, fetchPool: Function }) => {
     const [fetchError, setFetchError] = useState("");
     const [allCategories, setAllCategories] = useState<string[]>([]);
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+    const { selectedEditionKey } = useEdition();
 
     // Validation schema
     const schema = yup.object().shape({
@@ -59,7 +64,7 @@ const EditPool = ({ pool, fetchPool }: { pool: any, fetchPool: Function }) => {
         watch,
         formState: { errors },
     } = useForm<PoolForm>({
-        resolver: yupResolver(schema) as any,
+        resolver: yupResolver(schema) as Resolver<PoolForm>,
         defaultValues: {
             name: "",
             description: "",
@@ -74,25 +79,32 @@ const EditPool = ({ pool, fetchPool }: { pool: any, fetchPool: Function }) => {
         setFetchError("");
 
         const fetchCategories = async () => {
-            if (pool) {
-                setValue("name", pool.name);
-                setValue("description", pool.description);
-                setValue("public", pool.public);
-                setValue("categories", pool.categories);
+            if (!pool) {
+                return;
+            }
 
-                try {
-                    const categoriesResponse = await api.get("/categories");
-                    setAllCategories(categoriesResponse.data);
-                } catch (error) {
-                    setFetchError(t('pool.editPool.errors.fetchCategoriesFailed'));
-                }
+            setValue("name", pool.name);
+            setValue("description", pool.description || "");
+            setValue("public", pool.public);
+            setValue("categories", pool.categories);
+
+            try {
+                const categoriesResponse = await api.get("/categories", {
+                    params: {
+                        edition: pool.editionKey || selectedEditionKey,
+                    },
+                });
+                setAllCategories(categoriesResponse.data);
+            } catch (error) {
+                setFetchError(t('pool.editPool.errors.fetchCategoriesFailed'));
+            } finally {
+                setLoadingCategories(false);
+                setLoading(false);
             }
         };
 
         fetchCategories();
-        setLoadingCategories(false);
-        setLoading(false);
-    }, [pool]);
+    }, [pool, selectedEditionKey, setValue, t]);
 
     const onSubmit = async (data: PoolForm) => {
         setLoading(true);

--- a/front/src/pages/PoolInfo/PoolInfo.tsx
+++ b/front/src/pages/PoolInfo/PoolInfo.tsx
@@ -20,6 +20,7 @@ type Users = {
     admin: boolean;
 }
 type PoolInfoResponse = Pick<Pool, '_id' | 'name' | 'description' | 'public' | 'inviteToken' | 'categories' | 'createdBy' | 'createdAt'> & {
+    editionKey?: string;
     users: Users[];
     isUserInPool: boolean
     isAdmin: boolean;
@@ -107,6 +108,7 @@ const PoolInfo = () => {
             ) : (
                 <>
                     <Title>{title}</Title>
+                    {pool?.editionKey && <div className="badge badge-primary mb-4">{pool.editionKey}</div>}
 
                     <div className="card card-side shadow-xl md:mx-auto my-5 text-base-200 w-full">
                         <div role="tablist" className="tabs mx-auto w-full tabs-lifted tabs-sm overflow-x-auto">

--- a/front/src/pages/User/UserComponent.tsx
+++ b/front/src/pages/User/UserComponent.tsx
@@ -23,6 +23,10 @@ type UserResponse = {
     poolNumber: number;
 }
 
+type UsernameForm = {
+    username: string;
+};
+
 const UserPage = () => {
     const { t } = useTranslation();
     const navigate = useNavigate();
@@ -34,7 +38,7 @@ const UserPage = () => {
         register: registerUsername, 
         handleSubmit: handleSubmitUsername,
         formState: { errors: errorsUsername }
-    } = useForm({
+    } = useForm<UsernameForm>({
         resolver: yupResolver(usernameSchema)
     });
 
@@ -50,7 +54,7 @@ const UserPage = () => {
         fetchUser();
     }, []);
 
-    const handleUpdateUsername = async (data: any) => {
+    const handleUpdateUsername = async (data: UsernameForm) => {
         try {
             await api.put("/user", { username: data.username });
             setMsg({ type: 'success', content: t('user.updateSuccess') });
@@ -74,6 +78,11 @@ const UserPage = () => {
                     <a className="text-center mx-auto hover:cursor-pointer border border-base-100 p-2 rounded-lg hover:border-primary" onClick={() => navigate('/myPools')}>
                         {user.poolNumber} {t('user.pools')}
                     </a>
+                    {user.admin && (
+                        <button className="btn btn-outline btn-primary mt-3" onClick={() => navigate('/admin')}>
+                            {t('pages.admin')}
+                        </button>
+                    )}
 
                     {/* Formulário de Username */}
                     <div className="w-full max-w-md bg-base-100 p-6 rounded-box">

--- a/front/src/routes/routes.tsx
+++ b/front/src/routes/routes.tsx
@@ -13,6 +13,7 @@ import CreatePool from "../pages/CreatePool/CreatePool";
 import PoolInfo from "../pages/PoolInfo/PoolInfo";
 import FindPools from "../pages/FindPools/FindPools";
 import MyPools from "../pages/MyPools/MyPools";
+import AdminPage from "../pages/Admin/AdminPage";
 
 import Header from "../components/layout/Header";
 import Footer from "../components/layout/Footer";
@@ -55,6 +56,11 @@ const AppRoutes: React.FC = () => {
                     <Route path="/myPools" element={
                         <PrivateRoute>
                             <MyPools />
+                        </PrivateRoute>
+                    } />
+                    <Route path="/admin" element={
+                        <PrivateRoute admin>
+                            <AdminPage />
                         </PrivateRoute>
                     } />
                     


### PR DESCRIPTION
## Summary
- add backend edition support with Oscar 2026 seed data and edition-aware nominees, bets, pools, and winners
- add frontend edition context, public selector, and admin panel for edition activation
- harden Firebase Admin startup and fix pool listing routes for 2026 queries

## Testing
- cd back && npx tsc
- cd front && npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core data paths (bets, winners, pool listing/leaderboard) and adds seeding/migration logic plus new pagination cursors, so regressions could affect existing pools and navigation. Security/auth changes are limited to a new admin-only activation route and Firebase-availability gating.
> 
> **Overview**
> Introduces **multi-edition support** across backend + frontend, seeding `editions` (including Oscar 2026 placeholder nominees) and making nominees, winners, bet deadlines, bets, pool listings, and leaderboards resolve via an `editionKey` instead of hardcoded Oscar 2025 data.
> 
> Adds new backend endpoints under `/editions` (list, get active, activate with `adminMiddleware`) and updates pool creation/list/search pagination to be edition-filterable with a new cursor format, while migrating legacy pools to a default edition.
> 
> Frontend adds an `EditionProvider` + header selector, threads `edition`/`editionKey` through nominees and pool flows (create/find/my pools, pool info), and introduces an admin-only `/admin` page to activate editions; also hardens Firebase Admin initialization to fail gracefully with `503` on dependent routes when credentials are missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 055c17d7ad048db161b9f4f4dd4f9e8269d5d774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->